### PR TITLE
[#2] 초기 TCA 구조 세팅

### DIFF
--- a/NewsLetter/NewsLetter/Source/AppReducer.swift
+++ b/NewsLetter/NewsLetter/Source/AppReducer.swift
@@ -1,7 +1,0 @@
-//
-//  AppReducer.swift
-//  NewsLetter
-//
-//  Created by 이조은 on 7/12/25.
-//
-

--- a/NewsLetter/NewsLetter/Source/AppView.swift
+++ b/NewsLetter/NewsLetter/Source/AppView.swift
@@ -1,7 +1,0 @@
-//
-//  APPView.swift
-//  NewsLetter
-//
-//  Created by 이조은 on 7/12/25.
-//
-

--- a/NewsLetter/NewsLetter/Source/Application/AppReducer.swift
+++ b/NewsLetter/NewsLetter/Source/Application/AppReducer.swift
@@ -1,0 +1,26 @@
+//
+//  AppReducer.swift
+//  NewsLetter
+//
+//  Created by 이조은 on 7/12/25.
+//
+
+import ComposableArchitecture
+
+@Reducer
+struct AppReducer {
+    @ObservableState
+    struct State {
+        var home = HomeReducer.State()
+    }
+    
+    enum Action {
+        case home(HomeReducer.Action)
+    }
+    
+    var body: some Reducer<State, Action> {
+        Scope(state: \.home, action: \.home) {
+            HomeReducer()
+        }
+    }
+}

--- a/NewsLetter/NewsLetter/Source/Application/AppView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/AppView.swift
@@ -1,0 +1,18 @@
+//
+//  APPView.swift
+//  NewsLetter
+//
+//  Created by 이조은 on 7/12/25.
+//
+
+import SwiftUI
+
+import ComposableArchitecture
+
+struct AppView: View {
+    @Bindable var store: StoreOf<AppReducer>
+
+    var body: some View {
+        HomeView(store: store.scope(state: \.home, action: \.home))
+    }
+}

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Detail/DetailReducer.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Detail/DetailReducer.swift
@@ -5,3 +5,31 @@
 //  Created by 이조은 on 7/12/25.
 //
 
+import ComposableArchitecture
+
+@Reducer
+struct DetailReducer {
+    @ObservableState
+    struct State {
+        var title: String = "애플 ‘비밀번호 앱’ 서버를 스위프트로 바꿨더니"
+    }
+
+    enum Action: BindableAction {
+        case binding(BindingAction<State>)
+        case onAppear
+    }
+
+    @Dependency(\.dismiss) var dismiss
+
+    var body: some ReducerOf<Self> {
+        BindingReducer()
+        Reduce { state, action in
+            switch action {
+            case .onAppear:
+                return .none
+            default:
+                return .none
+            }
+        }
+    }
+}

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Detail/DetailView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Detail/DetailView.swift
@@ -5,3 +5,20 @@
 //  Created by 이조은 on 7/12/25.
 //
 
+import SwiftUI
+
+import ComposableArchitecture
+
+struct DetailView: View {
+    @Bindable var store: StoreOf<DetailReducer>
+
+    var body: some View {
+        Text("오늘의 뉴스 기사 제목: \n\(store.title)")
+    }
+}
+
+#Preview {
+    DetailView(store: Store(initialState: DetailReducer.State()) {
+        DetailReducer()
+    })
+}

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeReducer.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeReducer.swift
@@ -5,3 +5,45 @@
 //  Created by 이조은 on 7/12/25.
 //
 
+import ComposableArchitecture
+
+@Reducer
+struct HomeReducer {
+    @Reducer
+    enum Path {
+        case detail(DetailReducer)
+    }
+
+    @ObservableState
+    struct State {
+        var path = StackState<Path.State>()
+        var userName: String = "조은"
+    }
+
+    enum Action: BindableAction {
+        case binding(BindingAction<State>)
+        case path(StackActionOf<Path>)
+        case onAppear
+        case detailPressed
+    }
+
+    var body: some Reducer<State, Action> {
+        BindingReducer()
+
+        Reduce { state, action in
+            switch action {
+            case .onAppear:
+                print("HomeView Appear")
+                return .none
+
+            case .detailPressed:
+                state.path.append(.detail(DetailReducer.State()))
+                return .none
+
+            default:
+                return .none
+            }
+        }
+        .forEach(\.path, action: \.path)
+    }
+}

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
@@ -5,3 +5,44 @@
 //  Created by 이조은 on 7/12/25.
 //
 
+import SwiftUI
+
+import ComposableArchitecture
+
+struct HomeView: View {
+    @Bindable var store: StoreOf<HomeReducer>
+
+     var body: some View {
+         NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
+             VStack {
+                 Text("Welcome, \(store.userName)")
+                     .font(.headline)
+
+                 Button(action: {
+                     store.send(.detailPressed)
+                 }, label:{
+                     Text("Go to DetailView")
+                         .foregroundStyle(.white)
+                         .frame(width: 200, height: 42, alignment: .center)
+                         .background(.blue)
+                         .cornerRadius(8)
+                 })
+             }
+             .padding()
+         } destination: { store in
+             switch store.case {
+             case .detail(let store):
+                 DetailView(store: store)
+             }
+         }
+         .onAppear {
+             store.send(.onAppear)
+         }
+     }
+}
+
+#Preview {
+    HomeView(store: Store(initialState: HomeReducer.State()) {
+        HomeReducer()
+    })
+}

--- a/NewsLetter/NewsLetter/Source/Application/NewsLetterApp.swift
+++ b/NewsLetter/NewsLetter/Source/Application/NewsLetterApp.swift
@@ -7,11 +7,15 @@
 
 import SwiftUI
 
+import ComposableArchitecture
+
 @main
 struct NewsLetterApp: App {
+    let store = Store(initialState: AppReducer.State()) { AppReducer() }
+
     var body: some Scene {
         WindowGroup {
-//            ContentView()
+            AppView(store: store)
         }
     }
 }


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
TCA 구조를 세팅하였습니다.
- 최초에 앱이 켜지면 _NewsLetterApp -> AppView -> HomeView_  순서로 이동합니다.
- 화면 전환을 위해 `HomeReducer`에서 **StackState를 선언**하고, `HomeView`에서 **destination을 작성**해주었습니다.


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- close: #2 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
`AppView`에서 직접 HomeView를 사용하지 않고 `AppView -> HomeView` 구조로 분리한 이유 ❓

- 추후 `SplashView` 도입 가능성이 있으며, A/B 테스트 또는 플래그 기반 초기 진입 로직 (예: 최소 지원 버전 체크 등)을 삽입할 수 있는 유연한 진입점을 확보하기 위함입니다.
- 앱 실행 시점에 단순 화면 이동만이 아닌, 다양한 초기화를 수행할 수 있도록 아키텍처적으로 여지를 두고자 했습니다.

따라서, 현재는 곧바로 `HomeView`로 진입하지만 구조적으로 확장 가능성을 고려하여 `AppView`를 분리 구성했습니다.

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->
![Simulator Screen Recording - iPhone 16 Pro - 2025-07-15 at 00 16 08](https://github.com/user-attachments/assets/2391cc95-e615-4aca-bd06-998291e3ebc4)

