### PR TITLE
[#27] UserAPI 연동 

### DIFF
--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/Component/JobDetailBottomSheet/JobDetailBottomSheet.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/Component/JobDetailBottomSheet/JobDetailBottomSheet.swift
@@ -15,6 +15,8 @@ struct JobDetailBottomSheet: View {
         selectedCareer != nil && selectedJobCategory.isEmpty == false
     }
     
+    let confirmHandler: (Set<Int>, Int) -> Void
+    
     var body: some View {
         VStack {
             Text("정보를 등록하면\n매일 뉴스레터를 추천해 드려요")
@@ -73,6 +75,7 @@ struct JobDetailBottomSheet: View {
             Button(action: {
                 // TODO: 정보등록 API 호출
                 UserActionHistory.isAlreadyInputJobDetail = true
+                confirmHandler(selectedJobCategory, selectedCareer ?? 0)
             }) {
                 RoundedRectangle(cornerRadius: 100)
                     .frame(height: 56)

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/Component/NotificationPermissionBottomSheet.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/Component/NotificationPermissionBottomSheet.swift
@@ -53,10 +53,10 @@ struct NotificationPermissionBottomSheet: View {
                 if settings.authorizationStatus == .authorized {
                     UserActionHistory.isAlreadySetNotification = true
                     successHandler()
-                    // TODO: 알림등록 API 요청
                     isPresented = false
                 } else {
                     isCheckingPermission = true
+                    // TODO: 현재 앱 설정으로 이동은 하지만 알림메뉴가 표출되지 않는상황. 추후 알림메뉴 표출될 시 시나리오 테스트 필요
                     guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
                     
                     if UIApplication.shared.canOpenURL(url){

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeReducer.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeReducer.swift
@@ -45,6 +45,8 @@ struct HomeReducer {
         case timerStarted
         case setColorPalette([Color])
         case fetchCards
+        case registerUser
+        case updateUser(UserUpdateRequestDTO)
         case setCards([Card])
     }
     
@@ -53,7 +55,8 @@ struct HomeReducer {
     @Dependency(\.date.now) var now
     @Dependency(\.continuousClock) var clock
     @Dependency(\.cardClient) var cardClient
-    
+    @Dependency(\.userClient) var userClient
+
     var body: some Reducer<State, Action> {
         BindingReducer()
         
@@ -122,7 +125,30 @@ struct HomeReducer {
                         await send(.setCards([]))
                     }
                 }
-                
+            case .registerUser:
+                return .run { send in
+                    do {
+                        guard let deviceToken = KeychainManager.shared.retrieveString(forKey: "deviceToken") else {
+                            return
+                        }
+                        let requestDTO = UserRegisterRequestDTO(deviceToken: deviceToken)
+                        let userId = try await userClient.register(requestDTO)
+                        UserInfo.userId = userId
+                    } catch let error {
+                        // TODO: 에러 핸들링
+                        print(error.localizedDescription)
+                    }
+                }
+            case .updateUser(let dto):
+                return .run { send in
+                    do {
+                        guard let userId = UserInfo.userId else { return }
+                        try await userClient.update(userId, dto)
+                    } catch {
+                        // TODO: 에러 핸들링
+                        print(error.localizedDescription)
+                    }
+                }
             case .setCards(let cards):
                 state.cardData = cards
                 if state.cardData.isEmpty {

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
@@ -50,20 +50,7 @@ struct HomeView: View {
                                     source: item.newsletterName,
                                     onTap: {
                                         selectedIndex = index
-                                        
-                                        if cardTapCount >= 3 {
-                                            guard UserActionHistory.isAlreadyInputJobDetail == false &&
-                                                    DateCalculator.isCanShowJobDetailBottomSheet()
-                                            else {
-                                                isPresentModal = true
-                                                return
-                                            }
-                                            
-                                            isPresentJobDetailBottomSheet = true
-                                        } else {
-                                            isPresentModal = true
-                                        }
-                                        cardTapCount += 1
+                                        cardTapHandler()
                                     }
                                 )
                             }
@@ -78,11 +65,10 @@ struct HomeView: View {
                     dismissHandler: { UserActionHistory.deniedDateWhenInputJobDetail = Date() }
                 ) {
                     JobDetailBottomSheet { selectedJobCategory, selectedCareer in
-                        let preferences = selectedJobCategory.map { Preference.allCases[$0] }
-                        let workingExperience = WorkingExperience.allCases[selectedCareer]
-                        let requestDTO = UserUpdateRequestDTO(preferences: preferences, workingExperience: workingExperience)
-                        store.send(.updateUser(requestDTO))
-                        isPresentJobDetailBottomSheet = false
+                        jobDetailBottomSheetConfirmHandler(
+                            selectedJobCategory: selectedJobCategory,
+                            selectedCareer: selectedCareer
+                        )
                     }
                 }
                 .draggableBottomSheet(
@@ -98,6 +84,11 @@ struct HomeView: View {
                     )
                 }
                 .ignoresSafeArea(edges: .bottom)
+                .toastMessage(
+                    isPresented: $isPresentToastMessage,
+                    text: "뉴스레터 알림이 신청되었어요",
+                    bottomPadding: 0
+                )
                 .onAppear {
                     store.send(.onAppear(colorFlag: self.colorFlag))
                     store.send(.fetchCards)
@@ -114,11 +105,6 @@ struct HomeView: View {
                 .onDisappear {
                     store.send(.onDisappear)
                 }
-                .toastMessage(
-                    isPresented: $isPresentToastMessage,
-                    text: "뉴스레터 알림이 신청되었어요",
-                    bottomPadding: 0
-                )
                 
                 if isPresentModal {
                     CarouselModalView(
@@ -138,6 +124,38 @@ struct HomeView: View {
                 DetailView(store: store)
             }
         }
+    }
+    
+    // MARK: - Methods
+    
+    private func cardTapHandler() {
+        if cardTapCount >= 3 {
+            guard UserActionHistory.isAlreadyInputJobDetail == false &&
+                    DateCalculator.isCanShowJobDetailBottomSheet()
+            else {
+                isPresentModal = true
+                return
+            }
+            
+            isPresentJobDetailBottomSheet = true
+        } else {
+            isPresentModal = true
+        }
+        cardTapCount += 1
+    }
+    
+    private func jobDetailBottomSheetConfirmHandler(
+        selectedJobCategory: Set<Int>,
+        selectedCareer: Int
+    ) {
+        let preferences = selectedJobCategory.map { Preference.allCases[$0] }
+        let workingExperience = WorkingExperience.allCases[selectedCareer]
+        let requestDTO = UserUpdateRequestDTO(
+            preferences: preferences,
+            workingExperience: workingExperience
+        )
+        store.send(.updateUser(requestDTO))
+        isPresentJobDetailBottomSheet = false
     }
 }
 

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
@@ -19,7 +19,7 @@ struct HomeView: View {
     @State private var selectedIndex: Int?
     @State private var cardTapCount: Int = 0
     let cardTypes: [CardType] = [.one, .two, .three, .four, .five, .six]
-
+    
     var body: some View {
         NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
             ZStack {
@@ -50,7 +50,7 @@ struct HomeView: View {
                                     source: item.newsletterName,
                                     onTap: {
                                         selectedIndex = index
-
+                                        
                                         if cardTapCount >= 3 {
                                             guard UserActionHistory.isAlreadyInputJobDetail == false &&
                                                     DateCalculator.isCanShowJobDetailBottomSheet()
@@ -77,7 +77,13 @@ struct HomeView: View {
                     isShow: $isPresentJobDetailBottomSheet,
                     dismissHandler: { UserActionHistory.deniedDateWhenInputJobDetail = Date() }
                 ) {
-                    JobDetailBottomSheet()
+                    JobDetailBottomSheet { selectedJobCategory, selectedCareer in
+                        let preferences = selectedJobCategory.map { Preference.allCases[$0] }
+                        let workingExperience = WorkingExperience.allCases[selectedCareer]
+                        let requestDTO = UserUpdateRequestDTO(preferences: preferences, workingExperience: workingExperience)
+                        store.send(.updateUser(requestDTO))
+                        isPresentJobDetailBottomSheet = false
+                    }
                 }
                 .draggableBottomSheet(
                     isShow: $isPresentNotificationPermissionBottomSheet,
@@ -85,7 +91,10 @@ struct HomeView: View {
                 ) {
                     NotificationPermissionBottomSheet(
                         isPresented: $isPresentNotificationPermissionBottomSheet,
-                        successHandler: { isPresentToastMessage = true }
+                        successHandler: {
+                            store.send(.registerUser)
+                            isPresentToastMessage = true
+                        }
                     )
                 }
                 .ignoresSafeArea(edges: .bottom)

--- a/NewsLetter/NewsLetter/Source/Data/API/CardAPI.swift
+++ b/NewsLetter/NewsLetter/Source/Data/API/CardAPI.swift
@@ -17,7 +17,7 @@ enum CardAPI {
 
 extension CardAPI: TargetType {
     var baseURL: URL {
-        return URL(string: "http://\(BASE_URL)/api/api")!
+        return URL(string: "https://\(BASE_URL)/api/api")!
     }
 
     var path: String {

--- a/NewsLetter/NewsLetter/Source/Data/API/UserAPI.swift
+++ b/NewsLetter/NewsLetter/Source/Data/API/UserAPI.swift
@@ -20,7 +20,7 @@ extension UserAPI: TargetType {
     }
     
     var baseURL: URL {
-        return URL(string: "http://\(BASE_URL)/api/api")!
+        return URL(string: "https://\(BASE_URL)/api/api")!
     }
     
     var path: String {

--- a/NewsLetter/NewsLetter/Source/Data/API/UserAPI.swift
+++ b/NewsLetter/NewsLetter/Source/Data/API/UserAPI.swift
@@ -1,0 +1,60 @@
+//
+//  UserAPI.swift
+//  NewsLetter
+//
+//  Created by 이원빈 on 8/1/25.
+//
+
+import Foundation
+
+import Moya
+
+enum UserAPI {
+    case register(UserRegisterRequestDTO)
+    case update(userId: Int, requestDTO: UserUpdateRequestDTO)
+}
+
+extension UserAPI: TargetType {
+    var headers: [String : String]? {
+        return nil
+    }
+    
+    var baseURL: URL {
+        return URL(string: "http://\(BASE_URL)/api/api")!
+    }
+    
+    var path: String {
+        switch self {
+        case .register: return "/users/register"
+        case .update(let userId, _): return "/users/\(userId)"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .register: return .post
+        case .update: return .put
+        }
+    }
+    
+    var task: Task {
+        switch self {
+        case .register(let dto):
+            guard let parameters = dto.toDictionary() else {
+                return .requestPlain
+            }
+            return .requestParameters(
+                parameters: parameters,
+                encoding: JSONEncoding.default
+            )
+        case .update(_, let dto):
+            guard let parameters = dto.toDictionary() else {
+                return .requestPlain
+            }
+            return .requestParameters(
+                parameters: parameters,
+                encoding: JSONEncoding.default
+            )
+        }
+    }
+}

--- a/NewsLetter/NewsLetter/Source/Data/Client/UserClient.swift
+++ b/NewsLetter/NewsLetter/Source/Data/Client/UserClient.swift
@@ -1,0 +1,50 @@
+//
+//  UserClient.swift
+//  NewsLetter
+//
+//  Created by 이원빈 on 8/1/25.
+//
+
+import Combine
+
+import ComposableArchitecture
+import Moya
+
+@DependencyClient
+struct UserClient {
+    static let apiClient = MoyaAPIClient()
+    
+    var register: (UserRegisterRequestDTO) async throws -> Int
+    var update: (Int, UserUpdateRequestDTO) async throws -> Void
+}
+
+extension DependencyValues {
+    var userClient: UserClient {
+        get { self[UserClient.self] }
+        set { self[UserClient.self] = newValue }
+    }
+}
+
+extension UserClient: DependencyKey {
+    static var liveValue: UserClient = {
+       return UserClient(
+        register: { requestDTO in
+            let response = try await apiClient.request(UserAPI.register(requestDTO))
+            let dto = try response.map(UserRegisterResponseDTO.self)
+            return dto
+        },
+        update: { userId, requestDTO in
+            let _ = try await apiClient.request(UserAPI.update(userId: userId, requestDTO: requestDTO))
+        }
+       )
+    }()
+    
+    static var previewValue: UserClient = {
+        return UserClient(
+            register: { _ in return 0 },
+            update: { _, _ in return }
+        )
+    }()
+    
+    static var testValue: UserClient = previewValue
+}

--- a/NewsLetter/NewsLetter/Source/Data/Client/UserClient.swift
+++ b/NewsLetter/NewsLetter/Source/Data/Client/UserClient.swift
@@ -31,7 +31,7 @@ extension UserClient: DependencyKey {
         register: { requestDTO in
             let response = try await apiClient.request(UserAPI.register(requestDTO))
             let dto = try response.map(UserRegisterResponseDTO.self)
-            return dto
+            return dto.id
         },
         update: { userId, requestDTO in
             let _ = try await apiClient.request(UserAPI.update(userId: userId, requestDTO: requestDTO))

--- a/NewsLetter/NewsLetter/Source/Data/DTO/UserRegisterRequestDTO.swift
+++ b/NewsLetter/NewsLetter/Source/Data/DTO/UserRegisterRequestDTO.swift
@@ -1,0 +1,12 @@
+//
+//  UserRegisterRequestDTO.swift
+//  NewsLetter
+//
+//  Created by 이원빈 on 8/1/25.
+//
+
+import Foundation
+
+struct UserRegisterRequestDTO: Encodable {
+    let deviceToken: String
+}

--- a/NewsLetter/NewsLetter/Source/Data/DTO/UserRegisterResponseDTO.swift
+++ b/NewsLetter/NewsLetter/Source/Data/DTO/UserRegisterResponseDTO.swift
@@ -1,0 +1,10 @@
+//
+//  UserRegisterResponseDTO.swift
+//  NewsLetter
+//
+//  Created by 이원빈 on 8/1/25.
+//
+
+import Foundation
+
+typealias UserRegisterResponseDTO = Int

--- a/NewsLetter/NewsLetter/Source/Data/DTO/UserRegisterResponseDTO.swift
+++ b/NewsLetter/NewsLetter/Source/Data/DTO/UserRegisterResponseDTO.swift
@@ -7,4 +7,6 @@
 
 import Foundation
 
-typealias UserRegisterResponseDTO = Int
+struct UserRegisterResponseDTO: Decodable {
+    let id: Int
+}

--- a/NewsLetter/NewsLetter/Source/Data/DTO/UserUpdateRequestDTO.swift
+++ b/NewsLetter/NewsLetter/Source/Data/DTO/UserUpdateRequestDTO.swift
@@ -1,0 +1,32 @@
+//
+//  UserUpdateRequestDTO.swift
+//  NewsLetter
+//
+//  Created by 이원빈 on 8/1/25.
+//
+
+import Foundation
+
+// API 요청 DTO 모델
+struct UserUpdateRequestDTO: Codable {
+    let preference: [Preference]
+    let workingExperience: WorkingExperience
+}
+
+// 직군 정보 (preference)를 나타내는 열거형
+// 서버와 통신하는 API 명세에 따라 CaseIterable 프로토콜을 추가하면 유용할 수 있습니다.
+enum Preference: String, Codable, CaseIterable {
+    case android = "ANDROID"
+    case iOS = "IOS"
+    case frontend = "FRONTEND"
+    case backend = "BACKEND"
+}
+
+// 연차 정보 (workingExperience)를 나타내는 열거형
+enum WorkingExperience: String, Codable, CaseIterable {
+    case student = "STUDENT"
+    case junior = "JUNIOR"
+    case mid = "MID"
+    case senior = "SENIOR"
+    case expert = "EXPERT"
+}

--- a/NewsLetter/NewsLetter/Source/Data/DTO/UserUpdateRequestDTO.swift
+++ b/NewsLetter/NewsLetter/Source/Data/DTO/UserUpdateRequestDTO.swift
@@ -9,7 +9,7 @@ import Foundation
 
 // API 요청 DTO 모델
 struct UserUpdateRequestDTO: Codable {
-    let preference: [Preference]
+    let preferences: [Preference]
     let workingExperience: WorkingExperience
 }
 

--- a/NewsLetter/NewsLetter/Source/Data/UserInfo.swift
+++ b/NewsLetter/NewsLetter/Source/Data/UserInfo.swift
@@ -1,0 +1,14 @@
+//
+//  UserInfo.swift
+//  NewsLetter
+//
+//  Created by 이원빈 on 8/1/25.
+//
+
+import Foundation
+
+struct UserInfo {
+    /// 유저의 유니크 id
+    @UserDefaultWrapper(key: "userId", defaultValue: nil)
+    static var userId: Int?
+}

--- a/NewsLetter/NewsLetter/Source/Utils/Encodable+.swift
+++ b/NewsLetter/NewsLetter/Source/Utils/Encodable+.swift
@@ -1,0 +1,25 @@
+//
+//  Encodable+.swift
+//  NewsLetter
+//
+//  Created by 이원빈 on 8/1/25.
+//
+
+import Foundation
+
+extension Encodable {
+  func toDictionary() -> [String: Any]? {
+    let encoder = JSONEncoder()
+    guard let data = try? encoder.encode(self) else {
+      return nil
+    }
+    guard let dictionary = try? JSONSerialization.jsonObject(
+      with: data,
+      options: .allowFragments
+    ) as? [String: Any] else {
+      return nil
+    }
+    return dictionary
+  }
+}
+


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->

- 알림설정 BottomSheet, 정보등록 BottomSheet 에 버튼 탭시 API 요청 연동 작업 
- 변경된 서버 API 명세에 맞게 클라이언트 API 수정

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- close: #27 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->

알림설정 BottomSheet 에서 "알림받기" 탭시 앱 설정 화면으로 이동하지만, 알림 설정 섹션이 표출되지 않아 
정확한 테스트가 불가능합니다. 추후 알림기능 구현 후, 알림설정 메뉴가 표출될 것이니 그때 테스트 해보면 될 것 같습니다. 

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->

## 🔥 Test
<!-- Test -->
