### PR TITLE
[#44] fix: 캐로셀 나타나고 사라질 때 애니메이션 버그 해결

### DIFF
--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
@@ -113,6 +113,7 @@ struct HomeView: View {
                         firstLookHandler: { isPresentNotificationPermissionBottomSheet = true }
                     )
                     .transition(.opacity)
+                    .zIndex(1)
                 }
             }
             .animation(.easeInOut, value: isPresentModal)
@@ -131,13 +132,17 @@ struct HomeView: View {
             guard UserActionHistory.isAlreadyInputJobDetail == false &&
                     DateCalculator.isCanShowJobDetailBottomSheet()
             else {
-                isPresentModal = true
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    self.isPresentModal = true
+                }
                 return
             }
             
             isPresentJobDetailBottomSheet = true
         } else {
-            isPresentModal = true
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                self.isPresentModal = true
+            }
         }
         cardTapCount += 1
     }


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
- 캐로셀이 나타날 때 너무 바로 나타나서 카드가 클릭될 때 scale 애니메이션이 안 보여서
   -> 0.1초 뒤에 캐로셀이 나타나도록 하였습니다.

- 캐로셀이 사라질 때 HomeView에 있던 기존 UI들이 번쩍 거리는 버그가 있었는데
   -> zIndex를 사용하여 해결하였습니다.


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- close: #44 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
캐로셀이 사라질 때 기존에 밑에 있던 HomeUI가 번쩍 거렸던 이유는 ❓
> ZStack에서 뷰가 나타날 때는 애니메이션이 잘 적용되지만, 사라지게 할 때는 애니메이션 부자연스러워 보이는 문제가 있었습니다.
그 이유는 `CarouselModalView`가 사라지면서 그 아래 있던 `homeView`와 뷰의 **zIndex**(쌓임 순서)가 암묵적으로 0으로 동일해지기 때문입니다.

➡️ 따라서 캐로셀 뷰에 **명시적으로 zIndex(1)을 지정**해주어 HomeView 위에 위치 시켜주었습니다.

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->
[티스토리 블로그](https://doing-programming.tistory.com/entry/SwiftUI-%EC%95%A0%EB%8B%88%EB%A9%94%EC%9D%B4%EC%85%98-%EC%82%AC%EB%9D%BC%EC%A7%88-%EB%95%8C-%EB%8F%99%EC%9E%91%ED%95%98%EC%A7%80-%EC%95%8A%EB%8A%94-%EA%B2%BD%EC%9A%B0SwiftUI-Disappear-transition-not-animated)
https://sarunw.com/posts/how-to-fix-zstack-transition-animation-in-swiftui/
https://stackoverflow.com/questions/57730074/transition-animation-not-working-properly-in-swiftui


## 🔥 Test
<!-- Test -->
| 변경 전 | 변경 후 |
| ------ | ------ |
|   ![Simulator Screen Recording - iPhone 16 Pro - 2025-08-08 at 23 54 59](https://github.com/user-attachments/assets/b31b95ed-f859-4051-997f-2472324abe0f)   |   ![Simulator Screen Recording - iPhone 16 Pro - 2025-08-09 at 00 31 09](https://github.com/user-attachments/assets/7ad0eccd-3fdd-424a-b96c-0a2b15cb6b49)   |
