### PR TITLE
[#37] FCM 및 GA 이벤트 로그 연결

### DIFF
--- a/NewsLetter/NewsLetter.xcodeproj/project.pbxproj
+++ b/NewsLetter/NewsLetter.xcodeproj/project.pbxproj
@@ -11,6 +11,10 @@
 		023E73892E39066D00E63B83 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 023E73882E39066D00E63B83 /* FirebaseAnalytics */; };
 		023E73922E39076700E63B83 /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = 023E73912E39076700E63B83 /* FirebaseRemoteConfig */; };
 		0263F6D12E221A3C004837BB /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 0263F6D02E221A3C004837BB /* ComposableArchitecture */; };
+		02D608A72E4A44A800D39CD4 /* FirebaseAI in Frameworks */ = {isa = PBXBuildFile; productRef = 02D608A62E4A44A800D39CD4 /* FirebaseAI */; };
+		02D608A92E4A44A800D39CD4 /* FirebaseAnalyticsCore in Frameworks */ = {isa = PBXBuildFile; productRef = 02D608A82E4A44A800D39CD4 /* FirebaseAnalyticsCore */; };
+		02D608AB2E4A44A800D39CD4 /* FirebaseAnalyticsIdentitySupport in Frameworks */ = {isa = PBXBuildFile; productRef = 02D608AA2E4A44A800D39CD4 /* FirebaseAnalyticsIdentitySupport */; };
+		02D608AD2E4A44A800D39CD4 /* FirebaseAppCheck in Frameworks */ = {isa = PBXBuildFile; productRef = 02D608AC2E4A44A800D39CD4 /* FirebaseAppCheck */; };
 		AFD2BCAB2E233EF600E8319C /* CombineMoya in Frameworks */ = {isa = PBXBuildFile; productRef = AFD2BCAA2E233EF600E8319C /* CombineMoya */; };
 		AFD2BCAD2E233EF600E8319C /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = AFD2BCAC2E233EF600E8319C /* Moya */; };
 /* End PBXBuildFile section */
@@ -45,12 +49,16 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				02D608A72E4A44A800D39CD4 /* FirebaseAI in Frameworks */,
 				021B01F82E44D6FD003AD0C1 /* FirebaseMessaging in Frameworks */,
+				02D608AB2E4A44A800D39CD4 /* FirebaseAnalyticsIdentitySupport in Frameworks */,
 				AFD2BCAB2E233EF600E8319C /* CombineMoya in Frameworks */,
 				0263F6D12E221A3C004837BB /* ComposableArchitecture in Frameworks */,
 				023E73892E39066D00E63B83 /* FirebaseAnalytics in Frameworks */,
 				AFD2BCAD2E233EF600E8319C /* Moya in Frameworks */,
 				023E73922E39076700E63B83 /* FirebaseRemoteConfig in Frameworks */,
+				02D608AD2E4A44A800D39CD4 /* FirebaseAppCheck in Frameworks */,
+				02D608A92E4A44A800D39CD4 /* FirebaseAnalyticsCore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -107,6 +115,10 @@
 				023E73882E39066D00E63B83 /* FirebaseAnalytics */,
 				023E73912E39076700E63B83 /* FirebaseRemoteConfig */,
 				021B01F72E44D6FD003AD0C1 /* FirebaseMessaging */,
+				02D608A62E4A44A800D39CD4 /* FirebaseAI */,
+				02D608A82E4A44A800D39CD4 /* FirebaseAnalyticsCore */,
+				02D608AA2E4A44A800D39CD4 /* FirebaseAnalyticsIdentitySupport */,
+				02D608AC2E4A44A800D39CD4 /* FirebaseAppCheck */,
 			);
 			productName = NewsLetter;
 			productReference = AFA1FD4B2E2213C70064A381 /* NewsLetter.app */;
@@ -451,6 +463,26 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 0263F6CF2E221A3C004837BB /* XCRemoteSwiftPackageReference "swift-composable-architecture" */;
 			productName = ComposableArchitecture;
+		};
+		02D608A62E4A44A800D39CD4 /* FirebaseAI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 023E73852E39066D00E63B83 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAI;
+		};
+		02D608A82E4A44A800D39CD4 /* FirebaseAnalyticsCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 023E73852E39066D00E63B83 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalyticsCore;
+		};
+		02D608AA2E4A44A800D39CD4 /* FirebaseAnalyticsIdentitySupport */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 023E73852E39066D00E63B83 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalyticsIdentitySupport;
+		};
+		02D608AC2E4A44A800D39CD4 /* FirebaseAppCheck */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 023E73852E39066D00E63B83 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAppCheck;
 		};
 		AFD2BCAA2E233EF600E8319C /* CombineMoya */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/NewsLetter/NewsLetter.xcodeproj/project.pbxproj
+++ b/NewsLetter/NewsLetter.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		021B01F82E44D6FD003AD0C1 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 021B01F72E44D6FD003AD0C1 /* FirebaseMessaging */; };
 		023E73892E39066D00E63B83 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 023E73882E39066D00E63B83 /* FirebaseAnalytics */; };
 		023E73922E39076700E63B83 /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = 023E73912E39076700E63B83 /* FirebaseRemoteConfig */; };
 		0263F6D12E221A3C004837BB /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 0263F6D02E221A3C004837BB /* ComposableArchitecture */; };
@@ -44,6 +45,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				021B01F82E44D6FD003AD0C1 /* FirebaseMessaging in Frameworks */,
 				AFD2BCAB2E233EF600E8319C /* CombineMoya in Frameworks */,
 				0263F6D12E221A3C004837BB /* ComposableArchitecture in Frameworks */,
 				023E73892E39066D00E63B83 /* FirebaseAnalytics in Frameworks */,
@@ -104,6 +106,7 @@
 				AFD2BCAC2E233EF600E8319C /* Moya */,
 				023E73882E39066D00E63B83 /* FirebaseAnalytics */,
 				023E73912E39076700E63B83 /* FirebaseRemoteConfig */,
+				021B01F72E44D6FD003AD0C1 /* FirebaseMessaging */,
 			);
 			productName = NewsLetter;
 			productReference = AFA1FD4B2E2213C70064A381 /* NewsLetter.app */;
@@ -429,6 +432,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		021B01F72E44D6FD003AD0C1 /* FirebaseMessaging */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 023E73852E39066D00E63B83 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseMessaging;
+		};
 		023E73882E39066D00E63B83 /* FirebaseAnalytics */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 023E73852E39066D00E63B83 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;

--- a/NewsLetter/NewsLetter.xcodeproj/xcshareddata/xcschemes/NewsLetter.xcscheme
+++ b/NewsLetter/NewsLetter.xcodeproj/xcshareddata/xcschemes/NewsLetter.xcscheme
@@ -50,6 +50,12 @@
             ReferencedContainer = "container:NewsLetter.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-FIRAnalyticsDebugEnabled"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/NewsLetter/NewsLetter/Resource/Info.plist
+++ b/NewsLetter/NewsLetter/Resource/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>BASE_URL</key>
 	<string>$(BASE_URL)</string>
+	<key>FirebaseAppDelegateProxyEnabled</key>
+	<false/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
@@ -16,6 +18,11 @@
 		<string>Pretendard-Regular.otf</string>
 		<string>Pretendard-SemiBold.otf</string>
 		<string>JalnanGothic.otf</string>
+	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+		<string>fetch</string>
 	</array>
 </dict>
 </plist>

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/Component/CarouselModalView/CarouselCard.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/Component/CarouselModalView/CarouselCard.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 import WebKit
 
+import FirebaseAnalytics
+
 struct CarouselCard: View {
     private enum Metric {
         static let height: CGFloat = 366
@@ -19,6 +21,7 @@ struct CarouselCard: View {
     
     @State private var isWebViewPresented: Bool = false
     let card: Card
+    let index: Int
     let pointColor: Color
     
     var body: some View {
@@ -51,6 +54,18 @@ struct CarouselCard: View {
                 }
                 .onTapGesture {
                     isWebViewPresented = true
+
+                    let dataString = (try? JSONSerialization.data(withJSONObject: ["list_index": index]))
+                        .flatMap { String(data: $0, encoding: .utf8) } 
+
+                    Analytics.logEvent("click_newsletter_carousel", parameters: [
+                        "category": "click",
+                        "navigation": "newsletter_carousel",
+                        "object_section": "newsletter_card",
+                        "object_type": "newsletter",
+                        "object_id": card.title,
+                        "data": dataString ?? ""
+                    ])
                 }
                 .padding(.top, 16)
         }
@@ -68,5 +83,5 @@ struct CarouselCard: View {
 }
 
 #Preview {
-    CarouselCard(card: .stub(), pointColor: ColorPalette.pointPink500)
+    CarouselCard(card: .stub(), index: 0, pointColor: ColorPalette.pointPink500)
 }

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/Component/CarouselModalView/CarouselModalView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/Component/CarouselModalView/CarouselModalView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 import ComposableArchitecture
+import FirebaseAnalytics
 
 struct CarouselModalView: View {
     private enum Metric {
@@ -45,7 +46,7 @@ struct CarouselModalView: View {
                         ForEach(cardData.indices, id: \.self) { index in
                             let card = cardData[index]
                             let pointColor = pointColors[index]
-                            CarouselCard(card: card, pointColor: pointColor)
+                            CarouselCard(card: card, index: index, pointColor: pointColor)
                                 .frame(width: Metric.cardWidth)
                         }
                     }
@@ -90,6 +91,12 @@ struct CarouselModalView: View {
                 }
                 .padding(.top, 43)
             }
+        }
+        .onAppear() {
+            Analytics.logEvent(AnalyticsEventScreenView,
+           parameters: [
+            AnalyticsParameterScreenName: "newsletter_carousel"
+           ])
         }
     }
 }

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/Component/CarouselModalView/CarouselModalView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/Component/CarouselModalView/CarouselModalView.swift
@@ -20,6 +20,8 @@ struct CarouselModalView: View {
         static let xButtonSize: CGFloat = 44
     }
 
+    @State private var loggedImpressionIndices: Set<Int> = []
+
     @State var cardData: [Card]
     @State var pointColors: [Color]
     @Binding var isPresented: Bool
@@ -29,9 +31,7 @@ struct CarouselModalView: View {
 
     var body: some View {
         let cardData = Array(cardData.reversed())
-        let pointColors = Array(pointColors.reversed()
-            .dropFirst(pointColors.count - cardData.count))
-            .map { $0.toChangeColor() }
+        let pointColors = Array(pointColors.reversed().prefix(cardData.count)).map { $0.toChangeColor() }
 
         ZStack {
             Color.semanticColor.background_dimmed
@@ -66,6 +66,28 @@ struct CarouselModalView: View {
                         }
                     }
                 ))
+                .onChange(of: currentPage) { _, newPage in
+                    guard let newIndex = newPage else { return }
+
+                    if !loggedImpressionIndices.contains(newIndex) {
+                        let actualIndex = cardData.count - 1 - newIndex
+
+                        let card = cardData[actualIndex]
+                        let dataString = (try? JSONSerialization.data(withJSONObject: ["list_index": actualIndex]))
+                            .flatMap { String(data: $0, encoding: .utf8) }
+
+                        Analytics.logEvent("impression_newsletter_carousel", parameters: [
+                            "category": "impression",
+                            "navigation": "newsletter_carousel",
+                            "object_section": "newsletter_card",
+                            "object_type": "newsletter",
+                            "object_id": card.title,
+                            "data": dataString ?? ""
+                        ])
+
+                        loggedImpressionIndices.insert(actualIndex)
+                    }
+                }
 
                 HStack(spacing: Metric.indicatorSize) {
                     ForEach(0..<cardData.count, id: \.self) { index in
@@ -94,9 +116,27 @@ struct CarouselModalView: View {
         }
         .onAppear() {
             Analytics.logEvent(AnalyticsEventScreenView,
-           parameters: [
-            AnalyticsParameterScreenName: "newsletter_carousel"
-           ])
+                               parameters: [
+                                AnalyticsParameterScreenName: "newsletter_carousel"
+                               ])
+
+            if let initialIndex = currentPage, !loggedImpressionIndices.contains(initialIndex) {
+                let actualIndex = cardData.count-1-initialIndex
+                let card = cardData[actualIndex]
+                let dataString = (try? JSONSerialization.data(withJSONObject: ["list_index": actualIndex]))
+                    .flatMap { String(data: $0, encoding: .utf8) }
+
+                Analytics.logEvent("impression_newsletter_carousel", parameters: [
+                    "category": "impression",
+                    "navigation": "newsletter_carousel",
+                    "object_section": "newsletter_card",
+                    "object_type": "newsletter",
+                    "object_id": card.title,
+                    "data": dataString ?? ""
+                ])
+
+                loggedImpressionIndices.insert(actualIndex)
+            }
         }
     }
 }

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/Component/JobDetailBottomSheet/JobDetailBottomSheet.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/Component/JobDetailBottomSheet/JobDetailBottomSheet.swift
@@ -7,26 +7,28 @@
 
 import SwiftUI
 
+import FirebaseAnalytics
+
 struct JobDetailBottomSheet: View {
     @State private var selectedJobCategory: Set<Int> = []
     @State private var selectedCareer: Int?
-    
+
     private var isEnabledButton: Bool {
         selectedCareer != nil && selectedJobCategory.isEmpty == false
     }
-    
+
     let confirmHandler: (Set<Int>, Int) -> Void
-    
+
     var body: some View {
         VStack {
             Text("정보를 등록하면\n매일 뉴스레터를 추천해 드려요")
                 .font(.head22_bold)
                 .multilineTextAlignment(.center)
-            
+
             VStack(alignment: .leading) {
                 Text("관심직군")
                     .font(.body14_semiBold)
-                
+
                 LeftAlignedCollectionView<JobCell>(
                     data: .constant([
                         CellTypeData.init(
@@ -52,11 +54,11 @@ struct JobDetailBottomSheet: View {
                 .frame(height: 38)
             }
             .padding(.horizontal, 16)
-            
+
             VStack(alignment: .leading) {
                 Text("경력")
                     .font(.body14_semiBold)
-                
+
                 LeftAlignedCollectionView<CareerCell>(
                     data: .constant([
                         CellTypeData.init(text: "대학생 · 취준생"),
@@ -71,11 +73,35 @@ struct JobDetailBottomSheet: View {
                 .frame(height: 84)
             }
             .padding(.horizontal, 16)
-            
+
             Button(action: {
                 // TODO: 정보등록 API 호출
                 UserActionHistory.isAlreadyInputJobDetail = true
                 confirmHandler(selectedJobCategory, selectedCareer ?? 0)
+
+                let preferences = selectedJobCategory.map { Preference.allCases[$0].rawValue }
+
+                guard let selectedCareer = selectedCareer else {
+                    print("❌ 경력 정보가 선택되지 않았습니다.")
+                    return
+                }
+                let workingExperience = WorkingExperience.allCases[selectedCareer].rawValue
+
+                let dataDictionary: [String: Any] = [
+                    "job_group": preferences,
+                    "career_level": workingExperience
+                ]
+
+                let dataString = (try? JSONSerialization.data(withJSONObject: dataDictionary))
+                    .flatMap { String(data: $0, encoding: .utf8) }
+
+                Analytics.logEvent("bottom_sheet_custom_click", parameters: [
+                    "category": "click",
+                    "navigation": "bottom_sheet_custom",
+                    "object_section": "bottom_sheet",
+                    "object_type": "button",
+                    "user_properties": dataString ?? ""
+                ])
             }) {
                 RoundedRectangle(cornerRadius: 100)
                     .frame(height: 56)
@@ -88,6 +114,12 @@ struct JobDetailBottomSheet: View {
                     }
             }
             .disabled(!isEnabledButton)
+        }
+        .onAppear() {
+            Analytics.logEvent(AnalyticsEventScreenView,
+                               parameters: [
+                                AnalyticsParameterScreenName: "bottom_sheet_custom"
+                               ])
         }
     }
 }

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/Component/NotificationPermissionBottomSheet.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/Component/NotificationPermissionBottomSheet.swift
@@ -87,7 +87,7 @@ struct NotificationPermissionBottomSheet: View {
         Task {
             do {
                 let firebaseClient = FirebaseClient.liveValue
-                try await firebaseClient.sendDeviceToken(deviceToken, fcmToken, "IOS")
+                try await firebaseClient.sendDeviceToken(deviceToken, fcmToken)
             } catch {
                 print("=== ❌ FCM 토큰 등록 실패: \(error.localizedDescription)")
             }

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/Component/NotificationPermissionBottomSheet.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/Component/NotificationPermissionBottomSheet.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+import FirebaseAnalytics
 import FirebaseMessaging
 
 struct NotificationPermissionBottomSheet: View {
@@ -42,6 +43,12 @@ struct NotificationPermissionBottomSheet: View {
             }
             .padding(.top, 32)
         }
+        .onAppear() {
+            Analytics.logEvent(AnalyticsEventScreenView,
+           parameters: [
+            AnalyticsParameterScreenName: "bottom_sheet_notification"
+           ])
+        }
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase == .active && isCheckingPermission {
                 checkNotificationStatusAndDismissIfAllowed()
@@ -55,6 +62,11 @@ struct NotificationPermissionBottomSheet: View {
                 if granted {
                     self.sendTokenToServer()
 
+                    Analytics.logEvent("click_bottom_sheet_notification", parameters: [
+                        "category": "click",
+                        "navigation": "bottom_sheet_notification",
+                        "object_type": "button"
+                    ])
                     successHandler()
                     isPresented = false
                 } else {

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/Component/NotificationPermissionBottomSheet.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/Component/NotificationPermissionBottomSheet.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
+import FirebaseMessaging
+
 struct NotificationPermissionBottomSheet: View {
     @Environment(\.scenePhase) private var scenePhase
     @Binding var isPresented: Bool
@@ -46,27 +48,40 @@ struct NotificationPermissionBottomSheet: View {
             }
         }
     }
-    
+
     private func checkNotificationPermission() {
-        UNUserNotificationCenter.current().getNotificationSettings { settings in
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { granted, _ in
             DispatchQueue.main.async {
-                if settings.authorizationStatus == .authorized {
-                    UserActionHistory.isAlreadySetNotification = true
+                if granted {
+                    self.sendTokenToServer()
+
                     successHandler()
                     isPresented = false
                 } else {
                     isCheckingPermission = true
-                    // TODO: 현재 앱 설정으로 이동은 하지만 알림메뉴가 표출되지 않는상황. 추후 알림메뉴 표출될 시 시나리오 테스트 필요
-                    guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
-                    
-                    if UIApplication.shared.canOpenURL(url){
-                        UIApplication.shared.open(url)
-                    }
+                    isPresented = false
                 }
             }
         }
     }
-    
+
+    private func sendTokenToServer() {
+        guard let deviceToken = KeychainManager.shared.retrieveString(forKey: "deviceToken"),
+              let fcmToken = UserInfo.fcmToken
+        else {
+            return
+        }
+
+        Task {
+            do {
+                let firebaseClient = FirebaseClient.liveValue
+                try await firebaseClient.sendDeviceToken(deviceToken, fcmToken, "IOS")
+            } catch {
+                print("=== ❌ FCM 토큰 등록 실패: \(error.localizedDescription)")
+            }
+        }
+    }
+
     private func checkNotificationStatusAndDismissIfAllowed() {
         UNUserNotificationCenter.current().getNotificationSettings { settings in
             DispatchQueue.main.async {

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeReducer.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeReducer.swift
@@ -105,7 +105,6 @@ struct HomeReducer {
                 } else {
                     effects.append(.send(.fetchCards))
                 }
-                effects.append(.send(.fetchCards))
 
                 UserInfo.lastCardFetchDate = Date()
 

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
@@ -91,7 +91,6 @@ struct HomeView: View {
                 )
                 .onAppear {
                     store.send(.onAppear(colorFlag: self.colorFlag))
-                    print()
                     DateCalculator.checkAndIncrementVisitStreak()
                     
                     guard UserActionHistory.streakCount >= 2 &&

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 import ComposableArchitecture
+import FirebaseAnalytics
 
 struct HomeView: View {
     @Bindable var store: StoreOf<HomeReducer>
@@ -52,6 +53,18 @@ struct HomeView: View {
                                 onTap: {
                                     selectedIndex = index
                                     cardTapHandler()
+
+                                    let dataString = (try? JSONSerialization.data(withJSONObject: ["list_index": 5-index]))
+                                        .flatMap { String(data: $0, encoding: .utf8) }
+
+                                    Analytics.logEvent("click_newsletter", parameters: [
+                                        "category": "click",
+                                        "navigation": "main",
+                                        "object_section": "newsletter_list",
+                                        "object_type": "newsletter",
+                                        "object_id": item.title,
+                                        "data": dataString ?? ""
+                                    ])
                                 }
                             )
                         }
@@ -90,6 +103,11 @@ struct HomeView: View {
                     bottomPadding: 0
                 )
                 .onAppear {
+                    Analytics.logEvent(AnalyticsEventScreenView,
+                   parameters: [
+                    AnalyticsParameterScreenName: "main"
+                   ])
+
                     store.send(.onAppear(colorFlag: self.colorFlag))
                     DateCalculator.checkAndIncrementVisitStreak()
                     

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
@@ -54,7 +54,7 @@ struct HomeView: View {
                                     selectedIndex = index
                                     cardTapHandler()
 
-                                    let dataString = (try? JSONSerialization.data(withJSONObject: ["list_index": 5-index]))
+                                    let dataString = (try? JSONSerialization.data(withJSONObject: ["list_index": store.state.cardData.count-1-index]))
                                         .flatMap { String(data: $0, encoding: .utf8) }
 
                                     Analytics.logEvent("click_newsletter", parameters: [

--- a/NewsLetter/NewsLetter/Source/Application/NewsLetterApp.swift
+++ b/NewsLetter/NewsLetter/Source/Application/NewsLetterApp.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 import ComposableArchitecture
 import FirebaseCore
+import FirebaseMessaging
 
 @main
 struct NewsLetterApp: App {
@@ -32,7 +33,44 @@ class AppDelegate: NSObject, UIApplicationDelegate {
             KeychainManager.shared.saveString(newDeviceToken, forKey: "deviceToken")
             print("New Device Token: \(newDeviceToken)")
         }
+
         FirebaseApp.configure()
+
+        application.registerForRemoteNotifications()
+        Messaging.messaging().delegate = self
+        UNUserNotificationCenter.current().delegate = self
+
         return true
     }
+
+    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        Messaging.messaging().apnsToken = deviceToken
+    }
+}
+
+extension AppDelegate : MessagingDelegate {
+    func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+
+        if let fcmToken = fcmToken {
+            UserInfo.fcmToken = fcmToken
+        }
+    }
+}
+
+extension AppDelegate : UNUserNotificationCenterDelegate {
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                willPresent notification: UNNotification,
+                                withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+
+        let userInfo = notification.request.content.userInfo
+        completionHandler([.banner, .sound, .badge])
+    }
+
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                didReceive response: UNNotificationResponse,
+                                withCompletionHandler completionHandler: @escaping () -> Void) {
+        let userInfo = response.notification.request.content.userInfo
+        completionHandler()
+    }
+
 }

--- a/NewsLetter/NewsLetter/Source/Data/API/FirebaseAPI.swift
+++ b/NewsLetter/NewsLetter/Source/Data/API/FirebaseAPI.swift
@@ -1,0 +1,45 @@
+//
+//  FirebaseAPI.swift
+//  NewsLetter
+//
+//  Created by 이조은 on 8/7/25.
+//
+
+import Foundation
+
+import Moya
+
+enum FirebaseAPI {
+    case registerNotification(dto: RegisterNotificationRequestDTO)
+}
+
+extension FirebaseAPI: TargetType {
+    var baseURL: URL {
+        return URL(string: "https://\(BASE_URL)/api/api")!
+    }
+
+    var path: String {
+            switch self {
+            case .registerNotification:
+                return "/notifications/token"
+            }
+        }
+
+    var method: Moya.Method {
+        switch self {
+        case .registerNotification:
+            return .post
+        }
+    }
+
+    var headers: [String: String]? {
+        return ["Content-Type": "application/json"]
+    }
+
+    var task: Task {
+        switch self {
+        case .registerNotification(let dto):
+            return .requestJSONEncodable(dto)
+        }
+    }
+}

--- a/NewsLetter/NewsLetter/Source/Data/API/FirebaseAPI.swift
+++ b/NewsLetter/NewsLetter/Source/Data/API/FirebaseAPI.swift
@@ -19,11 +19,11 @@ extension FirebaseAPI: TargetType {
     }
 
     var path: String {
-            switch self {
-            case .registerNotification:
-                return "/notifications/token"
-            }
+        switch self {
+        case .registerNotification:
+            return "/notifications/token"
         }
+    }
 
     var method: Moya.Method {
         switch self {

--- a/NewsLetter/NewsLetter/Source/Data/Client/FirebaseClient.swift
+++ b/NewsLetter/NewsLetter/Source/Data/Client/FirebaseClient.swift
@@ -14,7 +14,7 @@ import Moya
 struct FirebaseClient {
     static let apiClient = MoyaAPIClient()
 
-    var sendDeviceToken: (_ deviceToken: String, _ fcmToken: String, _ deviceType: String) async throws -> Void
+    var sendDeviceToken: (_ deviceToken: String, _ fcmToken: String) async throws -> Void
 }
 
 extension DependencyValues {
@@ -27,7 +27,7 @@ extension DependencyValues {
 extension FirebaseClient: DependencyKey {
     static var liveValue: FirebaseClient = {
         return FirebaseClient(
-            sendDeviceToken: { deviceToken, fcmToken, deviceType in
+            sendDeviceToken: { deviceToken, fcmToken in
                 let dto = RegisterNotificationRequestDTO(
                     deviceToken: deviceToken,
                     fcmToken: fcmToken,
@@ -40,7 +40,7 @@ extension FirebaseClient: DependencyKey {
 
     static var previewValue: FirebaseClient = {
         return FirebaseClient(
-            sendDeviceToken: { _, _, _ in
+            sendDeviceToken: { _, _ in
                 print("📦 preview sendDeviceToken")
             }
         )

--- a/NewsLetter/NewsLetter/Source/Data/Client/FirebaseClient.swift
+++ b/NewsLetter/NewsLetter/Source/Data/Client/FirebaseClient.swift
@@ -1,0 +1,50 @@
+//
+//  FirebaseClient.swift
+//  NewsLetter
+//
+//  Created by 이조은 on 8/7/25.
+//
+
+import Combine
+
+import ComposableArchitecture
+import Moya
+
+@DependencyClient
+struct FirebaseClient {
+    static let apiClient = MoyaAPIClient()
+
+    var sendDeviceToken: (_ deviceToken: String, _ fcmToken: String, _ deviceType: String) async throws -> Void
+}
+
+extension DependencyValues {
+    var firebaseClient: FirebaseClient {
+        get { self[FirebaseClient.self] }
+        set { self[FirebaseClient.self] = newValue }
+    }
+}
+
+extension FirebaseClient: DependencyKey {
+    static var liveValue: FirebaseClient = {
+        return FirebaseClient(
+            sendDeviceToken: { deviceToken, fcmToken, deviceType in
+                let dto = RegisterNotificationRequestDTO(
+                    deviceToken: deviceToken,
+                    fcmToken: fcmToken,
+                    deviceType: "IOS"
+                )
+                _ = try await apiClient.request(FirebaseAPI.registerNotification(dto: dto))
+            }
+        )
+    }()
+
+    static var previewValue: FirebaseClient = {
+        return FirebaseClient(
+            sendDeviceToken: { _, _, _ in
+                print("📦 preview sendDeviceToken")
+            }
+        )
+    }()
+
+    static var testValue: FirebaseClient = previewValue
+}

--- a/NewsLetter/NewsLetter/Source/Data/DTO/NotificationRegisterRequestDTO.swift
+++ b/NewsLetter/NewsLetter/Source/Data/DTO/NotificationRegisterRequestDTO.swift
@@ -1,0 +1,12 @@
+//
+//  NotificationRegisterRequestDTO.swift
+//  NewsLetter
+//
+//  Created by 이조은 on 8/7/25.
+//
+
+struct RegisterNotificationRequestDTO: Encodable {
+    let deviceToken: String
+    let fcmToken: String
+    let deviceType: String
+}

--- a/NewsLetter/NewsLetter/Source/Data/UserInfo.swift
+++ b/NewsLetter/NewsLetter/Source/Data/UserInfo.swift
@@ -23,4 +23,8 @@ struct UserInfo {
     /// 유저가 마지막 API를 호출한 날짜
     @UserDefaultWrapper(key: "lastCardFetchDate", defaultValue: nil)
     static var lastCardFetchDate: Date?
+
+    /// 유저의 유니크 id
+    @UserDefaultWrapper(key: "fcmToken", defaultValue: nil)
+    static var fcmToken: String?
 }


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
- FCM 구현
- GA 로그 심기
  - pageView (main, newsletter_carousel, bottom_sheet_notification, bottom_sheet_custom)
  - click(main, newsletter_carousel, bottom_sheet_notification, bottom_sheet_custom)
  - impression(newsletter_carousel)


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- close: #37 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
- 현재 알림 허용 부분이 최초에 alert가 뜨고 설정하는 방법으로 구현되어 있습니다. 추후 설정 페이지에서는 알림 권한을 다시 설정하는 로직이 추가로 필요합니다.
- GA 관련 코드들이 View에 들어가면 UI 가독성을 해칠까봐 HomeReducer에 따로 빼고자 하였지만, 그러면 HomeReducer에 너무 많은 코드들이 추가되고 캐로셀과 바텀시트의 이벤트 추척 코드들을 handler로 만들어서 넘겨줘야 합니다. 그렇게 하면 추후에 리팩토링을 진행 할 때 더 복잡할 것 같아서 현재는 View에 이벤트 추척코드를 추가하고, 추후 팀원과 회의 후 새로운 reducer를 만들지 회의해보고 수정하겠습니다.

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->

| FCM 테스트 in App | FCM 테스트 in Background |
| ----------------- | --------------------------- |
| ![Simulator Screen Recording - iPhone 16 Pro - 2025-08-11 at 21 51 53](https://github.com/user-attachments/assets/c1848881-1a2e-48c9-98a2-a462cfc710e5) | ![Simulator Screen Recording - iPhone 16 Pro - 2025-08-11 at 21 46 08](https://github.com/user-attachments/assets/9d592bca-5799-4d52-b12f-42aae97ddb00) |

