### PR TITLE
[#62] QA 이슈 반영 2

### DIFF
--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/Component/JobDetailBottomSheet/JobDetailBottomSheet.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/Component/JobDetailBottomSheet/JobDetailBottomSheet.swift
@@ -87,6 +87,11 @@ struct JobDetailBottomSheet: View {
                 }
                 let workingExperience = WorkingExperience.allCases[selectedCareer].rawValue
 
+                if UserActionHistory.selectedCareer != [preferences, [workingExperience]] {
+                    UserActionHistory.isChangedCareer = true
+                    UserActionHistory.selectedCareer = [preferences, [workingExperience]]
+                }
+
                 let dataDictionary: [String: Any] = [
                     "job_group": preferences,
                     "career_level": workingExperience

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeReducer.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeReducer.swift
@@ -85,8 +85,13 @@ struct HomeReducer {
                    let cachedColors = UserInfo.cachedDailyColors?.map({ $0.color }),
                    !cachedColors.isEmpty {
 
-                    state.cardData = cachedCards
-                    state.cardColors = cachedColors
+                    if UserActionHistory.isChangedCareer == true {
+                        effects.append(.send(.fetchCards))
+                        UserActionHistory.isChangedCareer = false
+                    } else {
+                        state.cardData = cachedCards
+                        state.cardColors = cachedColors
+                    }
 
                 } else {
                     effects.append(.send(.fetchCards))

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeReducer.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeReducer.swift
@@ -43,7 +43,7 @@ struct HomeReducer {
         case onDisappear
         case settingPressed
         case tick
-        case timerStarted
+        case startTimer
         case setColorPalette([Color])
         case fetchCards
         case loginUser
@@ -72,23 +72,7 @@ struct HomeReducer {
                 var effects: [Effect<Action>] = []
                 
                 state.colorFlag = colorFlag
-
                 state.todayDate = DateCalculator.formattedDateStringForTitle()
-                state.remainingSeconds = DateCalculator.secondsUntilMidnight(from: self.now)
-
-                if !state.timerIsRunning {
-                    state.timerIsRunning = true
-
-                    effects.append(
-                        .run { send in
-                            await send(.timerStarted)
-                            for await _ in self.clock.timer(interval: .seconds(1)) {
-                                await send(.tick)
-                            }
-                        }
-                            .cancellable(id: CancelID.timer)
-                    )
-                }
 
                 let todayString = DateCalculator.formattedDateString()
                 let lastVisitString = UserInfo.lastCardFetchDate.map {
@@ -109,14 +93,15 @@ struct HomeReducer {
                 }
 
                 UserInfo.lastCardFetchDate = Date()
-                
+
+                let timerEffect = Effect<Action>.send(.startTimer)
                 let loginEffect = Effect<Action>.send(.loginUser)
                 let delayEffect = Effect<Action>.run { _ in
                     try await clock.sleep(for: .seconds(0.5))
                 }
                 let restEffect = Effect<Action>.merge(effects)
-                return .concatenate(loginEffect, delayEffect, restEffect)
-                
+                return .concatenate(timerEffect, loginEffect, delayEffect, restEffect)
+
             case let .setColorPalette(colors):
                 state.cardColors = colors
                 return .none
@@ -127,8 +112,17 @@ struct HomeReducer {
             case .settingPressed:
                 state.path.append(.setting(SettingReducer.State()))
                 return .none
-            case .timerStarted:
-                return .none
+            case .startTimer:
+                state.timerIsRunning = true
+                state.remainingSeconds = DateCalculator.secondsUntilMidnight(from: self.now)
+
+                return .run { send in
+                    await send(.startTimer)
+                    for await _ in self.clock.timer(interval: .seconds(1)) {
+                        await send(.tick)
+                    }
+                }
+                .cancellable(id: CancelID.timer, cancelInFlight: true)
 
             case .tick:
                 if state.remainingSeconds > 0 {

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
@@ -67,11 +67,13 @@ struct HomeView: View {
 
                     Spacer()
 
-                    Image("bg_drawers")
-                        .resizable()
-                        .frame(width: 600, height: Device.height*0.65)
-                        .padding(.bottom, Device.safeAreaInsets.bottom)
-//                        .frame(width: 600, height: 526)
+                    if store.state.cardData.count > 0 {
+                        Image("bg_drawers")
+                            .resizable()
+                            .frame(width: 600, height: Device.height*0.65)
+                            .padding(.bottom, Device.safeAreaInsets.bottom)
+                        //                        .frame(width: 600, height: 526)
+                    }
                 }
 
                 Group {

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
@@ -13,6 +13,8 @@ import FirebaseAnalytics
 struct HomeView: View {
     @Bindable var store: StoreOf<HomeReducer>
 
+    @Environment(\.scenePhase) private var scenePhase
+
     @State private var isPresentModal: Bool = false
     @State private var isPresentJobDetailBottomSheet: Bool = false
     @State private var isPresentNotificationPermissionBottomSheet: Bool = false
@@ -202,6 +204,11 @@ struct HomeView: View {
             }
             .onDisappear {
                 store.send(.onDisappear)
+            }
+            .onChange(of: scenePhase) { _, newPhase in
+                if newPhase == .active {
+                    store.send(.startTimer)
+                }
             }
         } destination: { store in
             switch store.case {

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
@@ -251,6 +251,7 @@ struct HomeView: View {
             workingExperience: workingExperience
         )
         store.send(.updateUser(requestDTO))
+        store.send(.onAppear(colorFlag: self.colorFlag))
         isPresentJobDetailBottomSheet = false
     }
 }

--- a/NewsLetter/NewsLetter/Source/Data/UserActionHistory.swift
+++ b/NewsLetter/NewsLetter/Source/Data/UserActionHistory.swift
@@ -19,7 +19,15 @@ struct UserActionHistory {
     /// 유저가 정보 등록을 완료했는지 여부
     @UserDefaultWrapper(key: "isAlreadyInputJobDetail", defaultValue: false)
     static var isAlreadyInputJobDetail: Bool
-    
+
+    /// 유저의 직군
+    @UserDefaultWrapper(key: "selectedCareer", defaultValue: [])
+    static var selectedCareer: [[String]]
+
+    /// 유저의 직군이 변경되었는지 확인
+    @UserDefaultWrapper(key: "isChangedCareer", defaultValue: false)
+    static var isChangedCareer: Bool
+
     /// 유저가 알림 받기를 완료했는지 여부
     @UserDefaultWrapper(key: "isAlreadySetNotification", defaultValue: false)
     static var isAlreadySetNotification: Bool


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
- 직군선택 시 카드리스트 다시 불러오기
- 백그라운드 -> 포어그라운드 전환했을 때 타이머 시간 변경
- 카드 데이터 없을 때 서랍장 이미지 없애기


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- close: #62 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
- 직군 변경 시 새로 카드 데이터를 불러오게 하였으나 실제 서버 응답으로 들어오는 카드 데이터가 동일하여 로그로 확인하도록 gif 첨부해두었습니다.
- 카드 펼쳐지는 애니메이션 적용 이후 최초 직군 선택 바텀 시트가 클릭이 안되는 이슈 발견했습니다. 추후 카드 스크롤 애니메이션 작업 때 레이아웃을 수정하면 해결될 것 같습니다.

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->

https://github.com/user-attachments/assets/181ac9b6-0a9b-403b-8c43-bdae338dbd9a


