### PR TITLE
[#75] refactor: GA 이벤트 로깅 전용 싱글톤 생성 및 적용

### DIFF
--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/Component/CarouselModalView/CarouselCard.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/Component/CarouselModalView/CarouselCard.swift
@@ -62,18 +62,8 @@ struct CarouselCard: View {
                 
                 Button {
                     isWebViewPresented = true
-                    
-                    let dataString = (try? JSONSerialization.data(withJSONObject: ["list_index": index]))
-                        .flatMap { String(data: $0, encoding: .utf8) }
-                    
-                    Analytics.logEvent("click_newsletter_carousel", parameters: [
-                        "category": "click",
-                        "navigation": "newsletter_carousel",
-                        "object_section": "newsletter_card",
-                        "object_type": "button",
-                        "object_id": card.title,
-                        "data": dataString ?? ""
-                    ])
+
+                    GA.click_newsletter_carousel(title: card.title, listIndex: index)
                 } label: {
                     RoundedRectangle(cornerRadius: Metric.nextButtonCornerRadius)
                         .stroke(.semanticColor.border_secondary, style: .init(lineWidth: 1))

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/Component/CarouselModalView/CarouselModalView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/Component/CarouselModalView/CarouselModalView.swift
@@ -73,17 +73,7 @@ struct CarouselModalView: View {
                         let actualIndex = cardData.count - 1 - newIndex
 
                         let card = cardData[actualIndex]
-                        let dataString = (try? JSONSerialization.data(withJSONObject: ["list_index": actualIndex]))
-                            .flatMap { String(data: $0, encoding: .utf8) }
-
-                        Analytics.logEvent("impression_newsletter_carousel", parameters: [
-                            "category": "impression",
-                            "navigation": "newsletter_carousel",
-                            "object_section": "newsletter_card",
-                            "object_type": "newsletter",
-                            "object_id": card.title,
-                            "data": dataString ?? ""
-                        ])
+                        GA.impression_newsletter_carousel(title: card.title, listIndex: actualIndex)
 
                         loggedImpressionIndices.insert(actualIndex)
                     }
@@ -118,24 +108,9 @@ struct CarouselModalView: View {
             if let initialIndex = currentPage, !loggedImpressionIndices.contains(initialIndex) {
                 let actualIndex = cardData.count-1-initialIndex
                 let card = cardData[actualIndex]
-                let dataString = (try? JSONSerialization.data(withJSONObject: ["list_index": actualIndex]))
-                    .flatMap { String(data: $0, encoding: .utf8) }
-                
-                Analytics.logEvent("pageview_newsletter_carousel", parameters: [
-                    "category": "pageview",
-                    "navigation": "newsletter_carousel",
-                    "object_type": "newsletter",
-                    "object_id": card.title
-                ])
 
-                Analytics.logEvent("impression_newsletter_carousel", parameters: [
-                    "category": "impression",
-                    "navigation": "newsletter_carousel",
-                    "object_section": "newsletter_card",
-                    "object_type": "newsletter",
-                    "object_id": card.title,
-                    "data": dataString ?? ""
-                ])
+                GA.pageview_newsletter_carousel(title: card.title)
+                GA.impression_newsletter_carousel(title: card.title, listIndex: actualIndex)
 
                 loggedImpressionIndices.insert(actualIndex)
             }

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/Component/JobDetailBottomSheet/JobDetailBottomSheet.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/Component/JobDetailBottomSheet/JobDetailBottomSheet.swift
@@ -101,17 +101,7 @@ struct JobDetailBottomSheet: View {
                     "job_group": preferences,
                     "career_level": workingExperience
                 ]
-
-                let dataString = (try? JSONSerialization.data(withJSONObject: dataDictionary))
-                    .flatMap { String(data: $0, encoding: .utf8) }
-
-                Analytics.logEvent("bottom_sheet_custom_click", parameters: [
-                    "category": "click",
-                    "navigation": "bottom_sheet_custom",
-                    "object_section": "bottom_sheet",
-                    "object_type": "button",
-                    "user_properties": dataString ?? ""
-                ])
+                GA.click_bottom_sheet_custom(userData: dataDictionary)
             } label: {
                 RoundedRectangle(cornerRadius: 100)
                     .frame(height: 56)
@@ -127,11 +117,7 @@ struct JobDetailBottomSheet: View {
             .disabled(!isEnabledButton)
         }
         .onAppear() {
-            Analytics.logEvent("pageview_bottom_sheet_custom", parameters: [
-                "category": "pageview",
-                "navigation": "bottom_sheet_custom",
-                "object_type": "bottom_sheet"
-            ])
+            GA.pageview_bottom_sheet_custom()
         }
     }
 }

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/Component/NotificationPermissionBottomSheet.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/Component/NotificationPermissionBottomSheet.swift
@@ -44,11 +44,7 @@ struct NotificationPermissionBottomSheet: View {
             .padding(.top, 32)
         }
         .onAppear() {
-            Analytics.logEvent("pageview_bottom_sheet_notification", parameters: [
-                "category": "pageview",
-                "navigation": "bottom_sheet_notification",
-                "object_type": "bottom_sheet",
-            ])
+            GA.pageview_bottom_sheet_notification()
         }
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase == .active && isCheckingPermission {
@@ -62,12 +58,7 @@ struct NotificationPermissionBottomSheet: View {
             DispatchQueue.main.async {
                 if granted {
                     self.sendTokenToServer()
-
-                    Analytics.logEvent("click_bottom_sheet_notification", parameters: [
-                        "category": "click",
-                        "navigation": "bottom_sheet_notification",
-                        "object_type": "button"
-                    ])
+                    GA.click_bottom_sheet_notification()
                     successHandler()
                     isPresented = false
                 } else {

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
@@ -93,7 +93,7 @@ struct HomeView: View {
                                 selectedIndex = index
                                 cardTapHandler()
 
-                                GA.click_newsletter_carousel(title: item.title, listIndex: store.state.cardData.count-1-index)
+                                GA.click_newsletter(title: item.title, listIndex: store.state.cardData.count-1-index)
                             },
                             isPresentModal: $isPresentModal,
                         )

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
@@ -93,17 +93,7 @@ struct HomeView: View {
                                 selectedIndex = index
                                 cardTapHandler()
 
-                                let dataString = (try? JSONSerialization.data(withJSONObject: ["list_index": store.state.cardData.count-1-index]))
-                                    .flatMap { String(data: $0, encoding: .utf8) }
-
-                                Analytics.logEvent("click_newsletter", parameters: [
-                                    "category": "click",
-                                    "navigation": "main",
-                                    "object_section": "newsletter_list",
-                                    "object_type": "newsletter",
-                                    "object_id": item.title,
-                                    "data": dataString ?? ""
-                                ])
+                                GA.click_newsletter_carousel(title: item.title, listIndex: store.state.cardData.count-1-index)
                             },
                             isPresentModal: $isPresentModal,
                         )
@@ -178,10 +168,7 @@ struct HomeView: View {
                 bottomPadding: 0
             )
             .onAppear {
-                Analytics.logEvent("pageview_main", parameters: [
-                    "category": "pageview",
-                    "navigation": "main"
-                ])
+                GA.pageview_main()
 
                 store.send(.onAppear(colorFlag: self.colorFlag))
                 

--- a/NewsLetter/NewsLetter/Source/Utils/AnalyticsManager.swift
+++ b/NewsLetter/NewsLetter/Source/Utils/AnalyticsManager.swift
@@ -1,0 +1,118 @@
+//
+//  AnalyticsManager.swift
+//  NewsLetter
+//
+//  Created by 이조은 on 9/28/25.
+//
+
+import Foundation
+
+import FirebaseAnalytics
+
+enum GA {
+
+    // MARK: - Newsletter Main
+
+    static func pageview_main() {
+        Analytics.logEvent("pageview_main", parameters: [
+            "category": "pageview",
+            "navigation": "main"
+        ])
+    }
+
+    static func click_newsletter(title: String, listIndex: Int) {
+        let dataString = encodeData(["list_index": listIndex])
+        Analytics.logEvent("click_newsletter", parameters: [
+            "category": "click",
+            "navigation": "main",
+            "object_section": "newsletter_list",
+            "object_type": "newsletter",
+            "object_id": title,
+            "data": dataString ?? ""
+        ])
+    }
+
+    // MARK: - Newsletter Carousel
+
+    static func pageview_newsletter_carousel(title: String) {
+        Analytics.logEvent("pageview_newsletter_carousel", parameters: [
+            "category": "pageview",
+            "navigation": "newsletter_carousel",
+            "object_type": "newsletter",
+            "object_id": title
+        ])
+    }
+
+    static func impression_newsletter_carousel(title: String, listIndex: Int) {
+        let dataString = encodeData(["list_index": listIndex])
+        Analytics.logEvent("impression_newsletter_carousel", parameters: [
+            "category": "impression",
+            "navigation": "newsletter_carousel",
+            "object_section": "newsletter_card",
+            "object_type": "newsletter",
+            "object_id": title,
+            "data": dataString ?? ""
+        ])
+    }
+
+    static func click_newsletter_carousel(title: String, listIndex: Int) {
+        let dataString = encodeData(["list_index": listIndex])
+        Analytics.logEvent("click_newsletter_carousel", parameters: [
+            "category": "click",
+            "navigation": "newsletter_carousel",
+            "object_section": "newsletter_card",
+            "object_type": "button",
+            "object_id": title,
+            "data": dataString ?? ""
+        ])
+    }
+
+    // MARK: - Bottom Sheet
+
+    static func pageview_bottom_sheet_notification() {
+        Analytics.logEvent("pageview_bottom_sheet_notification", parameters: [
+            "category": "pageview",
+            "navigation": "bottom_sheet_notification",
+            "object_type": "bottom_sheet"
+        ])
+    }
+
+    static func click_bottom_sheet_notification() {
+        Analytics.logEvent("click_bottom_sheet_notification", parameters: [
+            "category": "click",
+            "navigation": "bottom_sheet_notification",
+            "object_type": "button"
+        ])
+    }
+
+    static func pageview_bottom_sheet_custom() {
+        Analytics.logEvent("pageview_bottom_sheet_custom", parameters: [
+            "category": "pageview",
+            "navigation": "bottom_sheet_custom",
+            "object_type": "bottom_sheet"
+        ])
+    }
+
+    static func click_bottom_sheet_custom(userData: [String: Any]) {
+        let dataString = encodeData(userData)
+        Analytics.logEvent("click_bottom_sheet_custom", parameters: [
+            "category": "click",
+            "navigation": "bottom_sheet_custom",
+            "object_section": "bottom_sheet",
+            "object_type": "button",
+            "user_properties": dataString ?? ""
+        ])
+    }
+
+
+    // MARK: - Private Helper
+
+    private static func encodeData(_ dict: [String: Any]) -> String? {
+        guard let data = try? JSONSerialization.data(withJSONObject: dict),
+              let string = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return string
+    }
+}
+

--- a/NewsLetter/NewsLetter/Source/Utils/AnalyticsManager.swift
+++ b/NewsLetter/NewsLetter/Source/Utils/AnalyticsManager.swift
@@ -21,7 +21,7 @@ enum GA {
     }
 
     static func click_newsletter(title: String, listIndex: Int) {
-        let dataString = encodeData(["list_index": listIndex])
+        let dataString = ["list_index": listIndex].toJSONString()
         Analytics.logEvent("click_newsletter", parameters: [
             "category": "click",
             "navigation": "main",
@@ -44,7 +44,7 @@ enum GA {
     }
 
     static func impression_newsletter_carousel(title: String, listIndex: Int) {
-        let dataString = encodeData(["list_index": listIndex])
+        let dataString = ["list_index": listIndex].toJSONString()
         Analytics.logEvent("impression_newsletter_carousel", parameters: [
             "category": "impression",
             "navigation": "newsletter_carousel",
@@ -56,7 +56,7 @@ enum GA {
     }
 
     static func click_newsletter_carousel(title: String, listIndex: Int) {
-        let dataString = encodeData(["list_index": listIndex])
+        let dataString = ["list_index": listIndex].toJSONString()
         Analytics.logEvent("click_newsletter_carousel", parameters: [
             "category": "click",
             "navigation": "newsletter_carousel",
@@ -94,7 +94,7 @@ enum GA {
     }
 
     static func click_bottom_sheet_custom(userData: [String: Any]) {
-        let dataString = encodeData(userData)
+        let dataString = userData.toJSONString()
         Analytics.logEvent("click_bottom_sheet_custom", parameters: [
             "category": "click",
             "navigation": "bottom_sheet_custom",
@@ -102,17 +102,6 @@ enum GA {
             "object_type": "button",
             "user_properties": dataString ?? ""
         ])
-    }
-
-
-    // MARK: - Private Helper
-
-    private static func encodeData(_ dict: [String: Any]) -> String? {
-        guard let data = try? JSONSerialization.data(withJSONObject: dict),
-              let string = String(data: data, encoding: .utf8) else {
-            return nil
-        }
-        return string
     }
 }
 

--- a/NewsLetter/NewsLetter/Source/Utils/Dictionary+.swift
+++ b/NewsLetter/NewsLetter/Source/Utils/Dictionary+.swift
@@ -1,0 +1,18 @@
+//
+//  Dictionary+.swift
+//  NewsLetter
+//
+//  Created by 이조은 on 9/30/25.
+//
+
+import Foundation
+
+public extension Dictionary where Key == String, Value == Any {
+    func toJSONString() -> String? {
+        guard let data = try? JSONSerialization.data(withJSONObject: self),
+              let string = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return string
+    }
+}


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
- 중복과 오타를 줄이고, 이벤트 스키마를 일관되게 유지하기 위해 GA 이벤트 로깅 전용 싱글톤 생성 및 적용하였습니다.


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- close: #75 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->

## 🔥 Test
<!-- Test -->
| 1 |  2 |  3 | 
| -- | -- | -- | 
| <img width="960" height="258" alt="image" src="https://github.com/user-attachments/assets/9f3e146c-42be-4861-a6bb-7573d2b07ef1" /> | <img width="459" height="183" alt="image" src="https://github.com/user-attachments/assets/06ed66fb-d760-4030-881f-28e387532dcd" /> | <img width="952" height="298" alt="image" src="https://github.com/user-attachments/assets/59761bb4-904e-4417-9c4c-5429cf311dd3" /> |
| 4 |  5 |  6 |
| <img width="1000" height="366" alt="image" src="https://github.com/user-attachments/assets/ca58a69e-5d80-409d-8399-44fcccf1ac25" /> | <img width="922" height="370" alt="image" src="https://github.com/user-attachments/assets/cc53612b-2240-4d7e-a1c0-cf4a10139cab" /> | <img width="962" height="260" alt="image" src="https://github.com/user-attachments/assets/a0fd6de7-2acd-4f5b-8375-9ad3c74b519f" /> |
| 7 |  8 | 9 |
| <img width="924" height="368" alt="image" src="https://github.com/user-attachments/assets/514b175d-6b8e-4f85-9dcf-c3f555fdfd81" />| <img width="924" height="294" alt="image" src="https://github.com/user-attachments/assets/7a061ae1-87ec-4a03-82cd-ddfe1773d564" />| <img width="1006" height="256" alt="image" src="https://github.com/user-attachments/assets/ee80e8e8-e9ab-425a-b063-c36c88db8ed7" />|