### PR TITLE
[#79] fix: newletterName를 출처 텍스트로 사용하도록 수정

### DIFF
--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/Component/CarouselModalView/CarouselCard.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/Component/CarouselModalView/CarouselCard.swift
@@ -32,11 +32,19 @@ struct CarouselCard: View {
                 .font(.head20_bold)
                 .foregroundStyle(pointColor)
             
-            Text(card.topKeyword)
-                .fontRangeLimited()
-                .font(.body13_medium)
-                .foregroundStyle(pointColor)
-                .padding(.top, 4)
+            HStack(spacing: 6) {
+                Text(card.topKeyword)
+                    .font(.body13_medium)
+                
+                Rectangle()
+                    .frame(width: 1, height: 14)
+                
+                Text(card.newsletterName)
+                    .fontRangeLimited()
+                    .font(.body13_medium)
+            }
+            .foregroundStyle(pointColor)
+            .padding(.top, 4)
             
             Text(card.summary)
                 .fontRangeLimited()

--- a/NewsLetter/NewsLetter/Source/Domain/Entity/Card.swift
+++ b/NewsLetter/NewsLetter/Source/Domain/Entity/Card.swift
@@ -15,10 +15,10 @@ struct Card: Codable {
     // Card를 스텁 데이터로 초기화하는 함수
     static func stub(
         title: String = "일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔",
-        topKeyword: String = "Kotlin | 안드로이드 위클리",
+        topKeyword: String = "Kotlin",
         summary: String = "Anatolii Frolov는 Kotlin 객체 싱글톤이 Gson과 같은 라이브러리에 의해 복제될 수 있으므로 역직렬화할 때 실제 싱글톤 동작을 유지하려면 사용자 정의 어댑터가 필요하다고 강조합니다.Anatolii Frolov는 Kotlin 객체 싱글톤이 Gson과 같은 라이브러리에 의해 복제될 수 있으므로 역렬화할 때 실제 싱글톤 동작을 강조합니다.",
         contentURL: String = "https://substack.com/redirect/3966a1cb-5964-4e4c-a46c-67fd93586b71?j=eyJ1IjoiNjBoYXcyIn0.sgwjhuRgLj2i1p7EiKYAd1HGVttvTH1zz-7ivhBT090",
-        newsletterName: String = "Kotlin Article"
+        newsletterName: String = "안드로이드 위클리"
     ) -> Self {
         return .init(
             title: title,


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
newletterName를 출처 텍스트로 사용하도록 수정


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- close: #79 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
처음 개발할 때 신경쓰지 못하고 넘어갔던 부분인 거 같네요..! 
빠른 수정 완료했습니다

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->
<img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (3rd generation) - 2025-10-02 at 23 14 18" src="https://github.com/user-attachments/assets/665e260e-6b3b-4e1e-be7e-d13ded0ffea5" />
