### PR TITLE
fix: xcpretty_report_html String 복원 및 PROJECT_ROOT 경로 수정

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,7 +6,8 @@ default_platform(:ios)
 BUNDLE_ID     = "com.nexters.newsletter"
 SCHEME        = "NewsLetter"
 # CI 환경을 위해 프로젝트 루트 기준 절대 경로를 잡습니다.
-PROJECT_ROOT = Dir.pwd
+# __dir__ = fastlane/ 디렉토리, 상위(..) = repo root
+PROJECT_ROOT = File.expand_path('..', __dir__)
 PROJECT       = "NewsLetter/NewsLetter.xcodeproj"
 TARGET        = "NewsLetter"
 # 파일 생성 경로 (절대 경로로 생성하여 어긋남을 방지)
@@ -98,7 +99,7 @@ platform :ios do
       output_directory:  "./build",
       output_name:       "NewsLetter.ipa",
       # 상세 로그
-      xcpretty_report_html: true, # HTML 리포트 생성 (Artifact로 확인 가능)
+      xcpretty_report_html: "build/report.html", # HTML 리포트 생성 (Artifact로 확인 가능)
       silent: false,
       suppress_xcode_output: false,
       # pbxproj의 Release 설정에 'match Development' 프로파일이 지정되어 있으므로


### PR DESCRIPTION
## 문제

PR #102 머지 후 워크플로우가 여전히 실패. 실제 로그에서 2가지 버그 확인.

## 수정 내용

### Bug 1 — `xcpretty_report_html` 타입 오류
- PR #102에서 `"build/report.html"` → `true`로 잘못 수정
- gym은 Boolean이 아닌 **String(경로)**을 요구함
- 에러: `'xcpretty_report_html' value must be a String! Found TrueClass instead.`
- `true` → `"build/report.html"` 복원

### Bug 2 — `PROJECT_ROOT` 경로 오류
- CI에서 `Dir.pwd` = `fastlane/` 서브디렉토리
- xcconfig/plist가 `fastlane/NewsLetter/...`에 잘못 쓰이던 문제
- 로그 증거: `Writing xcconfig to: .../fastlane/NewsLetter/NewsLetter/Resource/secret.xcconfig`
- `Dir.pwd` → `File.expand_path('..', __dir__)` 로 수정 (`__dir__` = `fastlane/`, 상위 = repo root)