### PR TITLE
[#105] feature: 새로고침 버튼 터치 불가 버그 수정 및 A/B 테스트 플래그 코드 제거

### DIFF
--- a/NewsLetter/NewsLetter/Source/Application/AppReducer.swift
+++ b/NewsLetter/NewsLetter/Source/Application/AppReducer.swift
@@ -10,8 +10,7 @@ import Foundation
 
 @Reducer
 struct AppReducer {
-    typealias Flags = (colorFlag: String, mainDescFlag: String)
-
+    
     enum UpdateStatus: Equatable {
         case none
         case optional(storeURL: String, message: String)
@@ -65,16 +64,13 @@ struct AppReducer {
                 } else {
                     state.updateStatus = .none
                 }
-                let flags = (colorFlag: config.colorFlag, mainDescFlag: config.mainDescFlag)
-                return .send(.home(.setFlags(flags)))
+                return .none
 
             case .remoteConfigResponse(.failure(let error)):
                 print("Remote Config Fetch Error: \(error.localizedDescription)")
                 state.isLoading = false
                 state.updateStatus = .none
-                let defaultFlags = (colorFlag: "B", mainDescFlag: "F")
-                return .send(.home(.setFlags(defaultFlags)))
-
+                return .none
             case let .setUpdateStatus(status):
                 state.updateStatus = status
                 return .none

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeReducer.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeReducer.swift
@@ -12,8 +12,6 @@ import ComposableArchitecture
 
 @Reducer
 struct HomeReducer {
-    typealias Flags = (colorFlag: String, mainDescFlag: String)
-    
     @Reducer
     enum Path {
         case setting(SettingReducer)
@@ -24,10 +22,7 @@ struct HomeReducer {
         var path = StackState<Path.State>()
         var recommendState = RecommendReducer.State()
         var exploreState = ExploreReducer.State()
-        
         var selectedSegment: SegmentView.SegmentType = .recommend
-        var colorFlag: String = ""
-        var mainDescFlag: String = ""
         var isPresentModal: Bool = false
         var isPresentExploreCard: Bool = false
         var isPresentNotificationPermissionBottomSheet: Bool = false
@@ -44,7 +39,6 @@ struct HomeReducer {
         case recommend(RecommendReducer.Action)
         case explore(ExploreReducer.Action)
         case settingPressed
-        case setFlags(Flags)
         case submitNewsletterReport(NewsletterReportRequestDTO)
         case setIsPresentReportSuccessToast(Bool)
     }
@@ -88,10 +82,6 @@ struct HomeReducer {
                 return .none
             case .settingPressed:
                 state.path.append(.setting(SettingReducer.State()))
-                return .none
-            case .setFlags(let flags):
-                state.colorFlag = flags.colorFlag
-                state.mainDescFlag = flags.mainDescFlag
                 return .none
             case .submitNewsletterReport(let dto):
                 return .run { send in

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
@@ -26,9 +26,7 @@ struct HomeView: View {
                 case .recommend:
                     RecommendView(
                         store: store.scope(state: \.recommendState, action: \.recommend),
-                        selectedIndex: $store.selectedIndex,
-                        colorFlag: store.colorFlag,
-                        mainDescFlag: store.mainDescFlag
+                        selectedIndex: $store.selectedIndex
                     )
                 case .explore:
                     ExploreView(
@@ -130,7 +128,7 @@ struct HomeView: View {
             workingExperience: workingExperience
         )
         store.send(.recommend(.updateUser(requestDTO)))
-        store.send(.recommend(.onAppear(colorFlag: store.recommendState.colorFlag)))
+        store.send(.recommend(.onAppear))
         store.isPresentJobDetailBottomSheet = false
     }
 }

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/RecommendReducer.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/RecommendReducer.swift
@@ -13,7 +13,7 @@ import Moya
 
 @Reducer
 struct RecommendReducer {
-
+    
     @ObservableState
     struct State {
         var todayDate: String = ""
@@ -27,14 +27,13 @@ struct RecommendReducer {
         }
         
         var cardData: [Card] = []
-        var colorFlag: String = ""
         var cardColors: [Color] = []
         var isPresentModal: Bool = false
     }
     
     enum Action: BindableAction {
         case binding(BindingAction<State>)
-        case onAppear(colorFlag: String)
+        case onAppear
         case onDisappear
         case refreshButtonPressed
         case tick
@@ -62,7 +61,7 @@ struct RecommendReducer {
     @Dependency(\.continuousClock) var clock
     @Dependency(\.cardClient) var cardClient
     @Dependency(\.userClient) var userClient
-
+    
     var body: some Reducer<State, Action> {
         BindingReducer()
         
@@ -70,23 +69,21 @@ struct RecommendReducer {
             switch action {
             case .binding(_):
                 return .none
-            case let .onAppear(colorFlag):
+            case .onAppear:
                 var effects: [Effect<Action>] = []
-                
-                state.colorFlag = colorFlag
                 state.todayDate = DateCalculator.formattedDateStringForTitle()
-
+                
                 let todayString = DateCalculator.formattedDateString()
                 let lastVisitString = UserInfo.lastCardFetchDate.map {
                     DateCalculator.formattedDateString(from: $0)
                 } ?? ""
-
+                
                 if todayString == lastVisitString ,
                    let cachedCards = UserInfo.cachedDailyCards,
                    !cachedCards.isEmpty,
                    let cachedColors = UserInfo.cachedDailyColors?.map({ $0.color }),
                    !cachedColors.isEmpty {
-
+                    
                     if UserActionHistory.isChangedCareer == true {
                         effects.append(.send(.fetchCards))
                         UserActionHistory.isChangedCareer = false
@@ -94,13 +91,13 @@ struct RecommendReducer {
                         state.cardData = cachedCards
                         state.cardColors = cachedColors
                     }
-
+                    
                 } else {
                     effects.append(.send(.fetchCards))
                 }
-
+                
                 UserInfo.lastCardFetchDate = Date()
-
+                
                 let timerEffect = Effect<Action>.send(.startTimer)
                 let loginEffect = Effect<Action>.send(.loginUser)
                 let delayEffect = Effect<Action>.run { _ in
@@ -108,11 +105,11 @@ struct RecommendReducer {
                 }
                 let restEffect = Effect<Action>.merge(effects)
                 return .concatenate(timerEffect, loginEffect, delayEffect, restEffect)
-
+                
             case let .setColorPalette(colors):
                 state.cardColors = colors
                 return .none
-
+                
             case .onDisappear:
                 state.timerIsRunning = false
                 return .cancel(id: CancelID.timer)
@@ -135,25 +132,25 @@ struct RecommendReducer {
             case .startTimer:
                 state.timerIsRunning = true
                 state.remainingSeconds = DateCalculator.secondsUntilMidnight(from: self.now)
-
+                
                 return .run { send in
                     for await _ in self.clock.timer(interval: .seconds(1)) {
                         await send(.tick)
                     }
                 }
                 .cancellable(id: CancelID.timer, cancelInFlight: true)
-
+                
             case .tick:
                 if state.remainingSeconds > 0 {
                     state.remainingSeconds -= 1
                 } else {
                     state.todayDate = DateCalculator.formattedDateStringForTitle()
                     state.remainingSeconds = DateCalculator.secondsUntilMidnight(from: self.now)
-
+                    
                     UserInfo.lastCardFetchDate = nil
                     UserInfo.cachedDailyCards = nil
                     UserInfo.cachedDailyColors = nil
-
+                    
                     return .send(.fetchCards)
                 }
                 return .none
@@ -212,69 +209,32 @@ struct RecommendReducer {
             case .setCards(let cards):
                 state.cardData = cards
                 UserInfo.cachedDailyCards = cards
-
+                
                 if cards.isEmpty {
                     return .none
                 }
-
+                
                 UserInfo.lastCardFetchDate = Date()
-
-                if state.colorFlag == "A" {
-                    let colors = generateNewDailyColors(for: cards)
-                    let colorNames = colors.compactMap { ColorPaletteName.from(color: $0) }
-
-                    UserInfo.cachedDailyColors = colorNames
-
-                    return .send(.setColorPalette(Array(colors)))
-                } else {
-                    let fixedColors: [Color] = [
-                        ColorPalette.pointPurple200,
-                        ColorPalette.pointOrange400,
-                        ColorPalette.pointBlue300,
-                        ColorPalette.pointLemonYellow300,
-                        ColorPalette.pointPink300,
-                        ColorPalette.pointGreen300
-                    ]
-                    let colorNames = fixedColors.compactMap { ColorPaletteName.from(color: $0) }
-                    UserInfo.cachedDailyColors = colorNames
-
-                    return .send(.setColorPalette(fixedColors))
-                }
+                
+                let fixedColors: [Color] = [
+                    ColorPalette.pointPurple200,
+                    ColorPalette.pointOrange400,
+                    ColorPalette.pointBlue300,
+                    ColorPalette.pointLemonYellow300,
+                    ColorPalette.pointPink300,
+                    ColorPalette.pointGreen300
+                ]
+                
+                let colorNames = fixedColors.compactMap { ColorPaletteName.from(color: $0) }
+                UserInfo.cachedDailyColors = colorNames
+                
+                return .send(.setColorPalette(fixedColors))
             case .setIsPresentModal(let bool):
                 state.isPresentModal = bool
                 return .none
             case .delegate:
                 return .none
             }
-        }
-    }
-
-    private func generateNewDailyColors(for cardData: [Card], forceShuffle: Bool = true) -> [Color] {
-        let colorFamilies: [[Color]] = [
-            [ColorPalette.pointBlue300, ColorPalette.pointBlue200, ColorPalette.pointBlue400],
-            [ColorPalette.pointOrange400, ColorPalette.pointOrange300, ColorPalette.pointOrange500],
-            [ColorPalette.pointPink300, ColorPalette.pointPink200, ColorPalette.pointPink400],
-            [ColorPalette.pointPurple200, ColorPalette.pointPurple150, ColorPalette.pointPurple300],
-            [ColorPalette.pointGreen300, ColorPalette.pointGreen200, ColorPalette.pointGreen400],
-            [ColorPalette.pointLemonYellow300, ColorPalette.pointLemonYellow200, ColorPalette.pointLemonYellow400]
-        ]
-
-        let shuffledFamilies = colorFamilies.shuffled()
-        let uniqueCategories = Array(Set(cardData.map { $0.topKeyword }))
-        var categoryToFamilyMap: [String: [Color]] = [:]
-        for (index, category) in uniqueCategories.enumerated() {
-            categoryToFamilyMap[category] = shuffledFamilies[index % shuffledFamilies.count]
-        }
-        var categoryUsageCount: [String: Int] = [:]
-        return cardData.map { card in
-            let category = card.topKeyword
-            guard let colorFamily = categoryToFamilyMap[category] else {
-                return .gray
-            }
-            let usageIndex = categoryUsageCount[category, default: 0]
-            let selectedColor = colorFamily[usageIndex % colorFamily.count]
-            categoryUsageCount[category, default: 0] += 1
-            return selectedColor
         }
     }
 }

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/RecommendView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/RecommendView.swift
@@ -19,7 +19,6 @@ struct RecommendView: View {
     @State private var cardTapCount: Int = 0
     @State private var pulseOffsets: [Int: CGFloat] = [:]
     @State private var didAnimateSlot: Set<Int> = []
-    @State private var selectedSegment: SegmentView.SegmentType = .recommend
     
     @State private var start: Int = 0
     @State private var scrollAccum: CGFloat = 0

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/RecommendView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/RecommendView.swift
@@ -13,14 +13,14 @@ import FirebaseAnalytics
 struct RecommendView: View {
     @Bindable var store: StoreOf<RecommendReducer>
     @Binding var selectedIndex: Int?
-
+    
     @Environment(\.scenePhase) private var scenePhase
-
+    
     @State private var cardTapCount: Int = 0
     @State private var pulseOffsets: [Int: CGFloat] = [:]
     @State private var didAnimateSlot: Set<Int> = []
     @State private var selectedSegment: SegmentView.SegmentType = .recommend
-
+    
     @State private var start: Int = 0
     @State private var scrollAccum: CGFloat = 0
     @State private var progress: CGFloat = 0
@@ -28,79 +28,19 @@ struct RecommendView: View {
     @State private var isDragging: Bool = false
     @State private var cardHeights: [CGFloat] = []
     @State private var isCardAnimating: Bool = false
-
-    let colorFlag: String
-    let mainDescFlag: String
+    
     let cardTypes: [CardType] = [.one, .two, .three, .four, .five, .six]
-
+    
     var showRefreshButton: Bool {
         guard let refreshDate = UserActionHistory.useRefreshDate else { return true }
         return DateCalculator.isToday(date: refreshDate) == false
     }
-
+    
     var body: some View {
         ZStack(alignment: .bottom) {
             VStack(spacing: 0) {
-                VStack(spacing: 8) {
-                    Text((mainDescFlag == "T") ? "\(store.state.todayDate)" : "\(store.state.todayDate)\nToday's Hot News")
-                        .fontRangeLimited()
-                        .font(UIDevice.isSmallScreen || UIDevice.is13MiniScreen ? .jalnanGothicSE : .jalnanGothic)
-                        .multilineTextAlignment(.center)
-                        .foregroundColor(.semanticColor.text_strong)
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .padding(.top, UIDevice.isSmallScreen ? 4 : 12)
-                        .fixedSize(horizontal: false, vertical: true)
-
-                    if (mainDescFlag == "T") {
-                        Text("뉴스레터는 매일 새롭게 업데이트 돼요")
-                            .fontRangeLimited()
-                            .font(.body15_semiBold)
-                            .foregroundColor(.semanticColor.text_strong)
-                    }
-
-                    HStack(spacing: 0) {
-                        if (mainDescFlag == "T") {
-                            Text("아래 뉴스는 ")
-                                .font(.body15_medium)
-                                .foregroundColor(.semanticColor.text_secondary)
-                        }
-                        Text(store.state.formattedTime)
-                            .fontRangeLimited()
-                            .font(.body16_semiBold)
-                            .foregroundColor(.semanticColor.state_negative_primary)
-                        Text(" 동안 볼 수 있어요")
-                            .font(.body15_medium)
-                            .foregroundColor(.semanticColor.text_secondary)
-                    }
-
-                    if (mainDescFlag == "T") {
-                        Button {
-                            store.send(.refreshButtonPressed)
-                        } label: {
-                            HStack(spacing: 4) {
-                                Image("icon-sync-mono")
-                                    .renderingMode(.template)
-                                    .resizable()
-                                    .frame(width: 16, height: 16)
-                                    .foregroundStyle(showRefreshButton ? .semanticColor.text_secondary : .semanticColor.text_disabled)
-
-                                Text("새로고침 (\(showRefreshButton ? 0 : 1)/1)")
-                                    .font(.body14_semiBold)
-                                    .foregroundColor(showRefreshButton ? .semanticColor.text_secondary : .semanticColor.text_disabled)
-                            }
-                            .padding(.vertical, 6)
-                            .padding(.horizontal, 12)
-                            .background(
-                                RoundedRectangle(cornerRadius: 20)
-                                    .foregroundColor(showRefreshButton ? .semanticColor.fill_primary : .clear)
-                            )
-                        }
-                        .disabled(!showRefreshButton)
-                    }
-                }
-
                 Spacer()
-
+                
                 if store.state.cardData.count > 0 {
                     Image("bg_drawers")
                         .resizable()
@@ -108,37 +48,91 @@ struct RecommendView: View {
                         .padding(.bottom, Device.safeAreaInsets.bottom)
                 }
             }
-
+            .allowsHitTesting(false)
+            
             cardsStack
                 .padding(.bottom, -20)
                 .frame(width: Device.width)
                 .contentShape(Rectangle())
                 .simultaneousGesture(cardScrollGesture)
+            
+            VStack(spacing: 8) {
+                Text(store.state.todayDate)
+                    .fontRangeLimited()
+                    .font(UIDevice.isSmallScreen || UIDevice.is13MiniScreen ? .jalnanGothicSE : .jalnanGothic)
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(.semanticColor.text_strong)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.top, UIDevice.isSmallScreen ? 4 : 12)
+                    .fixedSize(horizontal: false, vertical: true)
+                
+                Text("뉴스레터는 매일 새롭게 업데이트 돼요")
+                    .fontRangeLimited()
+                    .font(.body15_semiBold)
+                    .foregroundColor(.semanticColor.text_strong)
+                
+                HStack(spacing: 0) {
+                    Text("아래 뉴스는 ")
+                        .font(.body15_medium)
+                        .foregroundColor(.semanticColor.text_secondary)
+                    Text(store.state.formattedTime)
+                        .fontRangeLimited()
+                        .font(.body16_semiBold)
+                        .foregroundColor(.semanticColor.state_negative_primary)
+                    Text(" 동안 볼 수 있어요")
+                        .font(.body15_medium)
+                        .foregroundColor(.semanticColor.text_secondary)
+                }
+                
+                Button {
+                    store.send(.refreshButtonPressed)
+                } label: {
+                    HStack(spacing: 4) {
+                        Image("icon-sync-mono")
+                            .renderingMode(.template)
+                            .resizable()
+                            .frame(width: 16, height: 16)
+                            .foregroundStyle(showRefreshButton ? .semanticColor.text_secondary : .semanticColor.text_disabled)
+                        
+                        Text("새로고침 (\(showRefreshButton ? 0 : 1)/1)")
+                            .font(.body14_semiBold)
+                            .foregroundColor(showRefreshButton ? .semanticColor.text_secondary : .semanticColor.text_disabled)
+                    }
+                    .padding(.vertical, 6)
+                    .padding(.horizontal, 12)
+                    .background(
+                        RoundedRectangle(cornerRadius: 20)
+                            .foregroundColor(showRefreshButton ? .semanticColor.fill_primary : .clear)
+                    )
+                }
+                .disabled(!showRefreshButton)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         }
         .animation(.easeInOut, value: store.isPresentModal)
         .ignoresSafeArea(edges: .all)
         .transition(.opacity)
         .onAppear {
             GA.pageview_main()
-
-            store.send(.onAppear(colorFlag: self.colorFlag))
-
+            
+            store.send(.onAppear)
+            
             if UserActionHistory.isFirstAppLaunch {
                 UserActionHistory.isFirstAppLaunch = false
-
+                
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                     store.send(.delegate(.presentJobDetailBottomSheet(true)))
                 }
             }
-
+            
             DateCalculator.checkAndIncrementVisitStreak()
-
+            
             guard UserActionHistory.streakCount >= 2 &&
                     UserActionHistory.isAlreadySetNotification == false &&
                     DateCalculator.isCanShowNotificationPermissionBottomSheet()
             else { return }
             store.send(.delegate(.presentNotificationPermissionBottomSheet(true)))
-
+            
             initializeCardHeights()
         }
         .onDisappear {
@@ -146,11 +140,11 @@ struct RecommendView: View {
         }
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase == .active {
-                store.send(.onAppear(colorFlag: self.colorFlag))
+                store.send(.onAppear)
             }
         }
     }
-
+    
     @ViewBuilder
     private var cardsStack: some View {
         let count = min(cardTypes.count, store.state.cardData.count)
@@ -168,16 +162,16 @@ struct RecommendView: View {
                             zIndex: -1
                         )
                     }
-
+                    
                     ForEach(0..<count, id: \.self) { slot in
                         let dataIndex = feedIndex(for: slot, count: count)
                         let item = store.state.cardData[dataIndex]
-
+                        
                         let currentDepth = CGFloat(slot) + progress
                         let style = interpolatedStyle(depth: currentDepth)
-
+                        
                         let translationY = calculateTranslationY(for: slot, count: count)
-
+                        
                         CardView(
                             style: style,
                             color: store.cardColors[dataIndex],
@@ -205,10 +199,10 @@ struct RecommendView: View {
                         .onAppear {
                             guard !didAnimateSlot.contains(slot) else { return }
                             didAnimateSlot.insert(slot)
-
+                            
                             let playOrder = (count - 1) - slot
                             let delayMs = playOrder * 150
-
+                            
                             DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(delayMs)) {
                                 withAnimation(.easeInOut(duration: 0.2)) {
                                     pulseOffsets[slot] = -5
@@ -221,7 +215,7 @@ struct RecommendView: View {
                             }
                         }
                     }
-
+                    
                     if progress < 0, count > 0 {
                         let lastSlot = count - 1
                         let dataIndex = feedIndex(for: 0, count: count)
@@ -236,12 +230,12 @@ struct RecommendView: View {
             }
         }
     }
-
+    
     private var cardScrollGesture: AnyGesture<DragGesture.Value> {
         if isScrollLocked {
             return AnyGesture(DragGesture(minimumDistance: .infinity))
         }
-
+        
         return AnyGesture(
             DragGesture(minimumDistance: 5)
                 .onChanged { value in
@@ -249,21 +243,21 @@ struct RecommendView: View {
                     let delta = value.translation.height - lastDragTranslation
                     lastDragTranslation = value.translation.height
                     scrollAccum += delta
-
+                    
                     let step = cardStep
                     let count = min(cardTypes.count, store.state.cardData.count)
                     guard count > 0 else { return }
-
+                    
                     while scrollAccum >= step {
                         start = (start + 1) % count
                         scrollAccum -= step
                     }
-
+                    
                     while scrollAccum <= -step {
                         start = (start - 1 + count) % count
                         scrollAccum += step
                     }
-
+                    
                     progress = scrollAccum / step
                 }
                 .onEnded { _ in
@@ -278,20 +272,20 @@ struct RecommendView: View {
                 }
         )
     }
-
+    
     private var isScrollLocked: Bool {
         isCardAnimating || store.isPresentModal
     }
-
+    
     private func lockCardScrollForTapAnimation() {
         guard isCardAnimating == false else { return }
         isCardAnimating = true
-
+        
         DispatchQueue.main.asyncAfter(deadline: .now() + CardView.tapAnimationTotalDuration) {
             isCardAnimating = false
         }
     }
-
+    
     @ViewBuilder
     private func phantomCardView(
         dataIndex: Int,
@@ -301,7 +295,7 @@ struct RecommendView: View {
     ) -> some View {
         let item = store.state.cardData[dataIndex]
         let style = interpolatedStyle(depth: CGFloat(targetSlot))
-
+        
         CardView(
             style: style,
             color: store.cardColors[dataIndex],
@@ -322,22 +316,22 @@ struct RecommendView: View {
         .position(x: Device.width / 2, y: positionY)
         .zIndex(zIndex)
     }
-
+    
     private func initializeCardHeights() {
         let count = min(cardTypes.count, store.state.cardData.count)
         guard count > 0 else { return }
-
+        
         cardHeights = (0..<count).map { index in
             if index == 0 { return 0 }
             return cardPositionY(at: index) - cardPositionY(at: index - 1)
         }
     }
-
+    
     private func getCardHeightDiff(at index: Int) -> CGFloat {
         guard index >= 0 && index < cardHeights.count else { return cardStep }
         return cardHeights[index]
     }
-
+    
     private func calculateTranslationY(for slot: Int, count: Int) -> CGFloat {
         if progress < 0 {
             if slot == 0 {
@@ -355,18 +349,18 @@ struct RecommendView: View {
             }
         }
     }
-
+    
     private func feedIndex(for slot: Int, count: Int) -> Int {
         (slot - start + count) % count
     }
-
+    
     private var cardStep: CGFloat {
         if UIDevice.isSmallScreen { return 80 }
         if UIDevice.is13MiniScreen { return 83 }
         if UIDevice.isLargeScreen { return 95 }
         return 90
     }
-
+    
     private func cardPositionY(at index: Int) -> CGFloat {
         if UIDevice.isSmallScreen {
             return Device.height - 430 + CGFloat(index * 80) - 100
@@ -378,7 +372,7 @@ struct RecommendView: View {
             return Device.height - 490 + CGFloat(index * 90) - 100
         }
     }
-
+    
     private func cardTapHandler() {
         if cardTapCount >= 3 {
             guard UserActionHistory.isAlreadyInputJobDetail == false &&
@@ -422,7 +416,5 @@ extension UIDevice {
     RecommendView(
         store: Store(initialState: RecommendReducer.State()) { RecommendReducer() },
         selectedIndex: .constant(nil),
-        colorFlag: "A",
-        mainDescFlag: "T"
     )
 }


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->

 [#105] 새로고침 버튼 터치 불가 버그 수정 및 A/B 테스트 플래그 코드 제거

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- close: #105
- 카드 스크롤 제스처 영역에 가려져 새로고침 버튼이 터치되지 않던 현상 수정
- 종료된 A/B 테스트(colorFlag, mainDescFlag) 관련 코드 전체 제거

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
- 기존에는 헤더(날짜 타이틀, 안내 문구, 새로고침 버튼)가 카드 스크롤 뷰와 동일한 VStack 안에 위치해, 카드 영역에 걸린 simultaneousGesture가 버튼 터치 이벤트를 가로막는 구조였음
- 헤더를 ZStack 최상단 레이어로 분리하고, 서랍장 배경 이미지를 담은 VStack에 .allowsHitTesting(false)를 추가해 터치 영역 충돌 해소
- A/B 테스트 종료 후 B 플래그(고정 색상 팔레트)가 사실상 기본 동작이 됐으므로, colorFlag / mainDescFlag 파라미터 및 분기 로직을AppReducer, HomeReducer, HomeView, RecommendReducer, RecommendView 전반에서 일괄 제거

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->
<img width="642" height="1389" alt="IMG_8979" src="https://github.com/user-attachments/assets/4135e08e-34fa-43f7-8674-518644b56ad9" />



## 🔥 Test
<!-- Test -->
