### PR TITLE
[#107] feat: 추천탭 UI 리뉴얼 및 캐로셀 개선

### DIFF
--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
@@ -36,12 +36,12 @@ struct HomeView: View {
             }
             .ignoresSafeArea()
             .overlay {
-                if store.isPresentModal {
-                    CarouselModalView(
-                        cardData: store.recommendState.cardData,
-                        pointColors: store.recommendState.cardColors,
+                if store.isPresentModal, let selectedIndex = store.selectedIndex {
+                    SingleModalView(
                         isPresented: $store.isPresentModal,
-                        currentPage: $store.selectedIndex,
+                        index: selectedIndex,
+                        cardData: store.recommendState.cardData[selectedIndex],
+                        pointColor: store.recommendState.cardColors[selectedIndex].main,
                         firstLookHandler: { store.isPresentNotificationPermissionBottomSheet = true }
                     )
                     .frame(width: Device.width)

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/Component/CardType.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/Component/CardType.swift
@@ -1,67 +1,67 @@
+////
+////  CardType.swift
+////  NewsLetter
+////
+////  Created by 이조은 on 7/26/25.
+////
+//import SwiftUI
 //
-//  CardType.swift
-//  NewsLetter
+//enum CardType {
+//    case one, two, three, four, five, six
 //
-//  Created by 이조은 on 7/26/25.
+//    var topPadding: CGFloat {
+//        switch self {
+//        case .one: return 16
+//        case .two, .three, .four, .five, .six: return 20
+//        }
+//    }
 //
-import SwiftUI
-
-enum CardType {
-    case one, two, three, four, five, six
-
-    var topPadding: CGFloat {
-        switch self {
-        case .one: return 16
-        case .two, .three, .four, .five, .six: return 20
-        }
-    }
-
-    var bottomPadding: CGFloat {
-        switch self {
-        case .one: return 12
-        case .two, .three, .four, .five, .six: return 16
-        }
-    }
-
-    var sidePadding: CGFloat {
-        switch self {
-        case .one: return 80
-        case .two: return 64
-        case .three: return 48
-        case .four: return 32
-        case .five: return 16
-        case .six: return 0
-        }
-    }
-
-    var fontName: FontStyle {
-        switch self {
-        case .one: return .body13_bold
-        case .two: return .body14_bold
-        case .three: return .body15_bold
-        case .four: return .body16_bold
-        case .five, .six: return .body18_bold
-        }
-    }
-
-    var fontNameSE: FontStyle {
-        switch self {
-        case .one: return .caption12_bold
-        case .two: return .body13_bold
-        case .three: return .body14_bold
-        case .four: return .body15_bold
-        case .five, .six: return .body16_bold
-        }
-    }
-
-    var oneLineHeight: Int {
-        switch self {
-        case .one:   return 19
-        case .two:   return 21
-        case .three: return 23
-        case .four:  return 25
-        case .five:  return 27
-        case .six:   return 27
-        }
-    }
-}
+//    var bottomPadding: CGFloat {
+//        switch self {
+//        case .one: return 12
+//        case .two, .three, .four, .five, .six: return 16
+//        }
+//    }
+//
+//    var sidePadding: CGFloat {
+//        switch self {
+//        case .one: return 80
+//        case .two: return 64
+//        case .three: return 48
+//        case .four: return 32
+//        case .five: return 16
+//        case .six: return 0
+//        }
+//    }
+//
+//    var fontName: FontStyle {
+//        switch self {
+//        case .one: return .body13_bold
+//        case .two: return .body14_bold
+//        case .three: return .body15_bold
+//        case .four: return .body16_bold
+//        case .five, .six: return .body18_bold
+//        }
+//    }
+//
+//    var fontNameSE: FontStyle {
+//        switch self {
+//        case .one: return .caption12_bold
+//        case .two: return .body13_bold
+//        case .three: return .body14_bold
+//        case .four: return .body15_bold
+//        case .five, .six: return .body16_bold
+//        }
+//    }
+//
+//    var oneLineHeight: Int {
+//        switch self {
+//        case .one:   return 19
+//        case .two:   return 21
+//        case .three: return 23
+//        case .four:  return 25
+//        case .five:  return 27
+//        case .six:   return 27
+//        }
+//    }
+//}

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/Component/CardTypeStyle.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/Component/CardTypeStyle.swift
@@ -1,91 +1,91 @@
+////
+////  CardTypeStyle.swift
+////  NewsLetter
+////
+////  Created by 이조은 on 1/28/26.
+////
 //
-//  CardTypeStyle.swift
-//  NewsLetter
+//import SwiftUI
 //
-//  Created by 이조은 on 1/28/26.
+//struct CardTypeStyle {
+//    var topPadding: CGFloat
+//    var bottomPadding: CGFloat
+//    var sidePadding: CGFloat
+//    var oneLineHeight: CGFloat
+//    var fontName: FontStyle
+//    var depth: CGFloat  // 0.0(.one) ~ 5.0(.six)
+//}
 //
-
-import SwiftUI
-
-struct CardTypeStyle {
-    var topPadding: CGFloat
-    var bottomPadding: CGFloat
-    var sidePadding: CGFloat
-    var oneLineHeight: CGFloat
-    var fontName: FontStyle
-    var depth: CGFloat  // 0.0(.one) ~ 5.0(.six)
-}
-
-
-extension CardType {
-    var depth: CGFloat {
-        switch self {
-        case .one: return 0
-        case .two: return 1
-        case .three: return 2
-        case .four: return 3
-        case .five: return 4
-        case .six: return 5
-        }
-    }
-
-    var style: CardTypeStyle {
-        CardTypeStyle(
-            topPadding: topPadding,
-            bottomPadding: bottomPadding,
-            sidePadding: sidePadding,
-            oneLineHeight: CGFloat(oneLineHeight),
-            fontName: UIDevice.isSmallScreen || UIDevice.is13MiniScreen ? fontNameSE : fontName,
-            depth: depth
-        )
-    }
-
-    static func fromIndex(_ i: Int) -> CardType {
-        switch i {
-        case 0: return .one
-        case 1: return .two
-        case 2: return .three
-        case 3: return .four
-        case 4: return .five
-        default: return .six
-        }
-    }
-}
-
-/// 선형 보간(Linear Interpolation): t(0~1)비율에 따라 a에서 b 사이의 값을 반환
-func lerp(_ a: CGFloat, _ b: CGFloat, _ t: CGFloat) -> CGFloat {
-    a + (b - a) * t
-}
-
-/// 연속적인 depth 값(0.0~5.0)으로부터 카드 스타일을 보간하여 생성
-/// 스크롤 시 카드 타입 간 부드러운 전환 애니메이션을 위해 사용
-func interpolatedStyle(depth: CGFloat) -> CardTypeStyle {
-    // depth를 0~5 범위로 클램핑
-    let clamped = min(max(depth, 0), 5)
-    // 인접한 두 카드 타입의 인덱스 산출 (예: depth 2.3 → lower: 2, upper: 3)
-    let lower = Int(floor(clamped))
-    let upper = min(lower + 1, 5)
-    // 두 카드 타입 사이의 보간 비율 (예: depth 2.3 → t: 0.3)
-    let t = clamped - CGFloat(lower)
-
-    let s0 = CardType.fromIndex(lower).style
-    let s1 = CardType.fromIndex(upper).style
-
-    // 패딩·높이 등 연속적인 수치 속성은 lerp로 부드럽게 보간
-    let top = lerp(s0.topPadding, s1.topPadding, t)
-    let bottom = lerp(s0.bottomPadding, s1.bottomPadding, t)
-    let side = lerp(s0.sidePadding, s1.sidePadding, t)
-    let lineH = lerp(s0.oneLineHeight, s1.oneLineHeight, t)
-
-    // 폰트는 보간이 불가능하므로 가까운 쪽(50% 기준)의 폰트를 선택
-    let fontName = (t < 0.5) ? s0.fontName : s1.fontName
-
-    return CardTypeStyle(
-        topPadding: top,
-        bottomPadding: bottom,
-        sidePadding: side,
-        oneLineHeight: lineH,
-        fontName: fontName,
-        depth: clamped
-    )
-}
+//
+//extension CardType {
+//    var depth: CGFloat {
+//        switch self {
+//        case .one: return 0
+//        case .two: return 1
+//        case .three: return 2
+//        case .four: return 3
+//        case .five: return 4
+//        case .six: return 5
+//        }
+//    }
+//
+//    var style: CardTypeStyle {
+//        CardTypeStyle(
+//            topPadding: topPadding,
+//            bottomPadding: bottomPadding,
+//            sidePadding: sidePadding,
+//            oneLineHeight: CGFloat(oneLineHeight),
+//            fontName: UIDevice.isSmallScreen || UIDevice.is13MiniScreen ? fontNameSE : fontName,
+//            depth: depth
+//        )
+//    }
+//
+//    static func fromIndex(_ i: Int) -> CardType {
+//        switch i {
+//        case 0: return .one
+//        case 1: return .two
+//        case 2: return .three
+//        case 3: return .four
+//        case 4: return .five
+//        default: return .six
+//        }
+//    }
+//}
+//
+///// 선형 보간(Linear Interpolation): t(0~1)비율에 따라 a에서 b 사이의 값을 반환
+//func lerp(_ a: CGFloat, _ b: CGFloat, _ t: CGFloat) -> CGFloat {
+//    a + (b - a) * t
+//}
+//
+///// 연속적인 depth 값(0.0~5.0)으로부터 카드 스타일을 보간하여 생성
+///// 스크롤 시 카드 타입 간 부드러운 전환 애니메이션을 위해 사용
+//func interpolatedStyle(depth: CGFloat) -> CardTypeStyle {
+//    // depth를 0~5 범위로 클램핑
+//    let clamped = min(max(depth, 0), 5)
+//    // 인접한 두 카드 타입의 인덱스 산출 (예: depth 2.3 → lower: 2, upper: 3)
+//    let lower = Int(floor(clamped))
+//    let upper = min(lower + 1, 5)
+//    // 두 카드 타입 사이의 보간 비율 (예: depth 2.3 → t: 0.3)
+//    let t = clamped - CGFloat(lower)
+//
+//    let s0 = CardType.fromIndex(lower).style
+//    let s1 = CardType.fromIndex(upper).style
+//
+//    // 패딩·높이 등 연속적인 수치 속성은 lerp로 부드럽게 보간
+//    let top = lerp(s0.topPadding, s1.topPadding, t)
+//    let bottom = lerp(s0.bottomPadding, s1.bottomPadding, t)
+//    let side = lerp(s0.sidePadding, s1.sidePadding, t)
+//    let lineH = lerp(s0.oneLineHeight, s1.oneLineHeight, t)
+//
+//    // 폰트는 보간이 불가능하므로 가까운 쪽(50% 기준)의 폰트를 선택
+//    let fontName = (t < 0.5) ? s0.fontName : s1.fontName
+//
+//    return CardTypeStyle(
+//        topPadding: top,
+//        bottomPadding: bottom,
+//        sidePadding: side,
+//        oneLineHeight: lineH,
+//        fontName: fontName,
+//        depth: clamped
+//    )
+//}

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/Component/CardView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/Component/CardView.swift
@@ -1,206 +1,206 @@
+////
+////  CardView.swift
+////  NewsLetter
+////
+////  Created by 이조은 on 7/19/25.
+////
 //
-//  CardView.swift
-//  NewsLetter
+//import SwiftUI
 //
-//  Created by 이조은 on 7/19/25.
+//struct CardView: View {
+//    let style: CardTypeStyle
+//    let color: Color
+//    let title: String
+//    let category: String
+//    let source: String
+//    let shouldMoveY: CGFloat
+//    var onTap: (() -> Void)? = nil
+//    var onTapBegan: (() -> Void)? = nil
 //
-
-import SwiftUI
-
-struct CardView: View {
-    let style: CardTypeStyle
-    let color: Color
-    let title: String
-    let category: String
-    let source: String
-    let shouldMoveY: CGFloat
-    var onTap: (() -> Void)? = nil
-    var onTapBegan: (() -> Void)? = nil
-
-    // 제목 최대 28글자까지
-    var trimmedTitle: String {
-        String(title.prefix(28))
-    }
-
-    @Binding var isPresentModal: Bool
-
-    @State private var titleHeight: CGFloat = 0
-    @State private var hideCategoryAndSource: Bool = false
-    @State private var vStackHeight: CGFloat = 0
-    @State private var titleBottomSpacing: CGFloat = 0
-    @State private var categoryBottomSpacing: CGFloat = 0
-    @State private var cardScale: CGFloat = 1.0
-    @State private var cardWidth: CGFloat? = nil
-    @State private var cardHeight: CGFloat? = nil
-    @State private var cardOffsetY: CGFloat = 0
-    @State private var cardZIndex: Double = Z.cardDefault
-    @State private var isTapped: Bool = false
-
-    private enum TapAnimation {
-        static let springDuration: TimeInterval = 0.5
-        static let expandDelay: TimeInterval = 0.5
-        static let expandDuration: TimeInterval = 0.5
-        static let totalDuration: TimeInterval = expandDelay + expandDuration
-    }
-
-    static let tapAnimationTotalDuration: TimeInterval = TapAnimation.totalDuration
-
-    init(
-        style: CardTypeStyle,
-        color: Color,
-        title: String,
-        category: String,
-        source: String,
-        shouldMoveY: CGFloat,
-        onTap: (() -> Void)? = nil,
-        onTapBegan: (() -> Void)? = nil,
-        isPresentModal: Binding<Bool>
-    ) {
-        self.style = style
-        self.color = color
-        self.title = title
-        self.category = category
-        self.source = source
-        self.shouldMoveY = shouldMoveY
-        self.onTap = onTap
-        self.onTapBegan = onTapBegan
-        self._isPresentModal = isPresentModal
-    }
-
-    var body: some View {
-        ZStack(alignment: .topLeading) {
-            RoundedRectangle(cornerRadius: 24)
-                .foregroundStyle(color)
-
-            VStack(alignment: .leading, spacing: 0) {
-                Text(trimmedTitle)
-                    .fontRangeLimited()
-                    .font(style.fontName)
-                    .foregroundStyle(.semanticColor.text_strong)
-                    .padding(.top, hideCategoryAndSource ? 16 : style.topPadding)
-                    .padding(.bottom, titleBottomSpacing)
-                    .background(
-                        GeometryReader { proxy in
-                            Color.clear
-                                .onAppear {
-                                    updateTitleLayout(height: proxy.size.height)
-                                }
-                                .onChange(of: proxy.size.height) { _, newValue in
-                                    DispatchQueue.main.async {
-                                        updateTitleLayout(height: newValue)
-                                    }
-                                }
-                        }
-                    )
-
-                if !hideCategoryAndSource {
-                    HStack(spacing: 6) {
-                        Text(category)
-                            .fontRangeLimited()
-                            .font(UIDevice.isSmallScreen ? .caption12_medium : .body13_medium)
-                            .foregroundStyle(.semanticColor.text_strong.opacity(0.5))
-
-                        Rectangle()
-                            .frame(width: 1, height: 14)
-                            .foregroundStyle(ColorPalette.black.opacity(0.1))
-
-                        Text(source)
-                            .fontRangeLimited()
-                            .font(UIDevice.isSmallScreen ? .caption12_medium : .body13_medium)
-                            .foregroundStyle(.semanticColor.text_strong.opacity(0.5))
-                    }
-                    .padding(.bottom, UIDevice.isSmallScreen ? 4 : style.bottomPadding)
-                }
-            }
-            .padding(.horizontal, 20)
-            .padding(.bottom, categoryBottomSpacing)
-            .background(
-                GeometryReader { proxy in
-                    Color.clear
-                        .onAppear {
-                            self.vStackHeight = proxy.size.height
-                        }
-                        .onChange(of: proxy.size.height) { _, newValue in
-                            self.vStackHeight = newValue
-                        }
-                }
-            )
-        }
-        .padding([.leading, .trailing], isTapped ? 0 : style.sidePadding)
-        .frame(width: cardWidth, height: cardHeight)
-        .offset(y: cardOffsetY)
-        .scaleEffect(cardScale)
-        .zIndex(cardZIndex)
-        .onTapGesture {
-            let generator = UIImpactFeedbackGenerator(style: .medium)
-            generator.impactOccurred()
-
-            onTapBegan?()
-            withAnimation(.spring(duration: TapAnimation.springDuration)) {
-                cardOffsetY = shouldMoveY
-                cardZIndex = Z.cardElevated
-                cardHeight = 300
-            }
-            DispatchQueue.main.asyncAfter(deadline: .now() + TapAnimation.expandDelay) {
-                withAnimation(.easeInOut(duration: TapAnimation.expandDuration)) {
-                    isTapped = true
-                    cardWidth = Device.width * 0.8
-                    cardHeight = 366
-                }
-            }
-            DispatchQueue.main.asyncAfter(deadline: .now() + TapAnimation.totalDuration) {
-                onTap?()
-            }
-        }
-        .onChange(of: isPresentModal) { _, newValue in
-            if newValue == false {
-                withAnimation(.spring(duration: TapAnimation.springDuration)) {
-                    cardOffsetY = 0
-                    isTapped = false
-                    cardWidth = nil
-                    cardHeight = vStackHeight == 0 ? nil : vStackHeight + 35
-                    cardZIndex = Z.cardDefault
-                }
-            }
-        }
-        .onAppear {
-            cardHeight = vStackHeight == 0 ? nil : vStackHeight + 35
-        }
-    }
-
-    private func updateTitleLayout(height: CGFloat) {
-        let calculatedTitleHeight = height - (hideCategoryAndSource ? 16 : style.topPadding) - titleBottomSpacing
-
-        if abs(titleHeight - calculatedTitleHeight) > 0.5 || titleHeight == 0 {
-            titleHeight = calculatedTitleHeight
-
-            if style.depth < 3 {
-                let shouldHide = calculatedTitleHeight >= style.oneLineHeight
-                if hideCategoryAndSource != shouldHide {
-                    hideCategoryAndSource = shouldHide
-                    titleBottomSpacing = shouldHide
-                        ? (style.depth >= 1 && style.depth < 2 ? 12 : style.bottomPadding)
-                        : 4
-                }
-            } else {
-                hideCategoryAndSource = false
-                titleBottomSpacing = 4
-                let shouldHide = calculatedTitleHeight >= style.oneLineHeight
-                if !shouldHide {
-                    categoryBottomSpacing = UIDevice.isSmallScreen ? CGFloat(4) : style.oneLineHeight
-                }
-            }
-        }
-    }
-}
-
-#Preview {
-    VStack(spacing: -35) {
-        CardView(style: CardType.one.style, color: .accentColor.purple, title: "사이드 프로젝트, AI로 출시까지? 지금 바로", category: "Kotlin", source: "안드로이드 위클리", shouldMoveY: 0, onTap: { print("===") }, isPresentModal: .constant(false))
-        CardView(style: CardType.two.style, color: .accentColor.orange, title: "SwiftUI 한 줄 코드로 번역? 믿기지 않죠!", category: "Kotlin", source: "안드로이드 위클리", shouldMoveY: 0, isPresentModal: .constant(false))
-        CardView(style: CardType.three.style, color: .accentColor.skyblue, title: "일이삼사오육칠팔구십일이삼사오육칠", category: "Kotlin", source: "안드로이드 위클리", shouldMoveY: 0, isPresentModal: .constant(false))
-        CardView(style: CardType.four.style, color: .accentColor.lemonyellow, title: "직장인이라면 알아야 할 주 4일제의 모든 것", category: "Kotlin", source: "안드로이드 위클리", shouldMoveY: 0, isPresentModal: .constant(false))
-        CardView(style: CardType.five.style, color: .accentColor.pink, title: "일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔", category: "Kotlin", source: "안드로이드 위클리", shouldMoveY: 0, isPresentModal: .constant(false))
-        CardView(style: CardType.six.style, color: .accentColor.green, title: "일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔", category: "Kotlin", source: "안드로이드 위클리", shouldMoveY: 0, isPresentModal: .constant(false))
-    }
-}
+//    // 제목 최대 28글자까지
+//    var trimmedTitle: String {
+//        String(title.prefix(28))
+//    }
+//
+//    @Binding var isPresentModal: Bool
+//
+//    @State private var titleHeight: CGFloat = 0
+//    @State private var hideCategoryAndSource: Bool = false
+//    @State private var vStackHeight: CGFloat = 0
+//    @State private var titleBottomSpacing: CGFloat = 0
+//    @State private var categoryBottomSpacing: CGFloat = 0
+//    @State private var cardScale: CGFloat = 1.0
+//    @State private var cardWidth: CGFloat? = nil
+//    @State private var cardHeight: CGFloat? = nil
+//    @State private var cardOffsetY: CGFloat = 0
+//    @State private var cardZIndex: Double = Z.cardDefault
+//    @State private var isTapped: Bool = false
+//
+//    private enum TapAnimation {
+//        static let springDuration: TimeInterval = 0.5
+//        static let expandDelay: TimeInterval = 0.5
+//        static let expandDuration: TimeInterval = 0.5
+//        static let totalDuration: TimeInterval = expandDelay + expandDuration
+//    }
+//
+//    static let tapAnimationTotalDuration: TimeInterval = TapAnimation.totalDuration
+//
+//    init(
+//        style: CardTypeStyle,
+//        color: Color,
+//        title: String,
+//        category: String,
+//        source: String,
+//        shouldMoveY: CGFloat,
+//        onTap: (() -> Void)? = nil,
+//        onTapBegan: (() -> Void)? = nil,
+//        isPresentModal: Binding<Bool>
+//    ) {
+//        self.style = style
+//        self.color = color
+//        self.title = title
+//        self.category = category
+//        self.source = source
+//        self.shouldMoveY = shouldMoveY
+//        self.onTap = onTap
+//        self.onTapBegan = onTapBegan
+//        self._isPresentModal = isPresentModal
+//    }
+//
+//    var body: some View {
+//        ZStack(alignment: .topLeading) {
+//            RoundedRectangle(cornerRadius: 24)
+//                .foregroundStyle(color)
+//
+//            VStack(alignment: .leading, spacing: 0) {
+//                Text(trimmedTitle)
+//                    .fontRangeLimited()
+//                    .font(style.fontName)
+//                    .foregroundStyle(.semanticColor.text_strong)
+//                    .padding(.top, hideCategoryAndSource ? 16 : style.topPadding)
+//                    .padding(.bottom, titleBottomSpacing)
+//                    .background(
+//                        GeometryReader { proxy in
+//                            Color.clear
+//                                .onAppear {
+//                                    updateTitleLayout(height: proxy.size.height)
+//                                }
+//                                .onChange(of: proxy.size.height) { _, newValue in
+//                                    DispatchQueue.main.async {
+//                                        updateTitleLayout(height: newValue)
+//                                    }
+//                                }
+//                        }
+//                    )
+//
+//                if !hideCategoryAndSource {
+//                    HStack(spacing: 6) {
+//                        Text(category)
+//                            .fontRangeLimited()
+//                            .font(UIDevice.isSmallScreen ? .caption12_medium : .body13_medium)
+//                            .foregroundStyle(.semanticColor.text_strong.opacity(0.5))
+//
+//                        Rectangle()
+//                            .frame(width: 1, height: 14)
+//                            .foregroundStyle(ColorPalette.black.opacity(0.1))
+//
+//                        Text(source)
+//                            .fontRangeLimited()
+//                            .font(UIDevice.isSmallScreen ? .caption12_medium : .body13_medium)
+//                            .foregroundStyle(.semanticColor.text_strong.opacity(0.5))
+//                    }
+//                    .padding(.bottom, UIDevice.isSmallScreen ? 4 : style.bottomPadding)
+//                }
+//            }
+//            .padding(.horizontal, 20)
+//            .padding(.bottom, categoryBottomSpacing)
+//            .background(
+//                GeometryReader { proxy in
+//                    Color.clear
+//                        .onAppear {
+//                            self.vStackHeight = proxy.size.height
+//                        }
+//                        .onChange(of: proxy.size.height) { _, newValue in
+//                            self.vStackHeight = newValue
+//                        }
+//                }
+//            )
+//        }
+//        .padding([.leading, .trailing], isTapped ? 0 : style.sidePadding)
+//        .frame(width: cardWidth, height: cardHeight)
+//        .offset(y: cardOffsetY)
+//        .scaleEffect(cardScale)
+//        .zIndex(cardZIndex)
+//        .onTapGesture {
+//            let generator = UIImpactFeedbackGenerator(style: .medium)
+//            generator.impactOccurred()
+//
+//            onTapBegan?()
+//            withAnimation(.spring(duration: TapAnimation.springDuration)) {
+//                cardOffsetY = shouldMoveY
+//                cardZIndex = Z.cardElevated
+//                cardHeight = 300
+//            }
+//            DispatchQueue.main.asyncAfter(deadline: .now() + TapAnimation.expandDelay) {
+//                withAnimation(.easeInOut(duration: TapAnimation.expandDuration)) {
+//                    isTapped = true
+//                    cardWidth = Device.width * 0.8
+//                    cardHeight = 366
+//                }
+//            }
+//            DispatchQueue.main.asyncAfter(deadline: .now() + TapAnimation.totalDuration) {
+//                onTap?()
+//            }
+//        }
+//        .onChange(of: isPresentModal) { _, newValue in
+//            if newValue == false {
+//                withAnimation(.spring(duration: TapAnimation.springDuration)) {
+//                    cardOffsetY = 0
+//                    isTapped = false
+//                    cardWidth = nil
+//                    cardHeight = vStackHeight == 0 ? nil : vStackHeight + 35
+//                    cardZIndex = Z.cardDefault
+//                }
+//            }
+//        }
+//        .onAppear {
+//            cardHeight = vStackHeight == 0 ? nil : vStackHeight + 35
+//        }
+//    }
+//
+//    private func updateTitleLayout(height: CGFloat) {
+//        let calculatedTitleHeight = height - (hideCategoryAndSource ? 16 : style.topPadding) - titleBottomSpacing
+//
+//        if abs(titleHeight - calculatedTitleHeight) > 0.5 || titleHeight == 0 {
+//            titleHeight = calculatedTitleHeight
+//
+//            if style.depth < 3 {
+//                let shouldHide = calculatedTitleHeight >= style.oneLineHeight
+//                if hideCategoryAndSource != shouldHide {
+//                    hideCategoryAndSource = shouldHide
+//                    titleBottomSpacing = shouldHide
+//                        ? (style.depth >= 1 && style.depth < 2 ? 12 : style.bottomPadding)
+//                        : 4
+//                }
+//            } else {
+//                hideCategoryAndSource = false
+//                titleBottomSpacing = 4
+//                let shouldHide = calculatedTitleHeight >= style.oneLineHeight
+//                if !shouldHide {
+//                    categoryBottomSpacing = UIDevice.isSmallScreen ? CGFloat(4) : style.oneLineHeight
+//                }
+//            }
+//        }
+//    }
+//}
+//
+//#Preview {
+//    VStack(spacing: -35) {
+//        CardView(style: CardType.one.style, color: .accentColor.purple, title: "사이드 프로젝트, AI로 출시까지? 지금 바로", category: "Kotlin", source: "안드로이드 위클리", shouldMoveY: 0, onTap: { print("===") }, isPresentModal: .constant(false))
+//        CardView(style: CardType.two.style, color: .accentColor.orange, title: "SwiftUI 한 줄 코드로 번역? 믿기지 않죠!", category: "Kotlin", source: "안드로이드 위클리", shouldMoveY: 0, isPresentModal: .constant(false))
+//        CardView(style: CardType.three.style, color: .accentColor.skyblue, title: "일이삼사오육칠팔구십일이삼사오육칠", category: "Kotlin", source: "안드로이드 위클리", shouldMoveY: 0, isPresentModal: .constant(false))
+//        CardView(style: CardType.four.style, color: .accentColor.lemonyellow, title: "직장인이라면 알아야 할 주 4일제의 모든 것", category: "Kotlin", source: "안드로이드 위클리", shouldMoveY: 0, isPresentModal: .constant(false))
+//        CardView(style: CardType.five.style, color: .accentColor.pink, title: "일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔", category: "Kotlin", source: "안드로이드 위클리", shouldMoveY: 0, isPresentModal: .constant(false))
+//        CardView(style: CardType.six.style, color: .accentColor.green, title: "일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔", category: "Kotlin", source: "안드로이드 위클리", shouldMoveY: 0, isPresentModal: .constant(false))
+//    }
+//}

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/Component/CarouselModalView/SingleModalView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/Component/CarouselModalView/SingleModalView.swift
@@ -1,0 +1,66 @@
+//
+//  SingleModalView.swift
+//  NewsLetter
+//
+//  Created by 이원빈 on 5/3/26.
+//
+
+import SwiftUI
+
+import ComposableArchitecture
+import FirebaseAnalytics
+
+struct SingleModalView: View {
+    private enum Metric {
+        static let cardWidth: CGFloat = UIScreen.main.bounds.width * 0.8
+        static let cardHeight: CGFloat = 366
+        static let xButtonSize: CGFloat = 44
+    }
+    
+    @Binding var isPresented: Bool
+    
+    let index: Int
+    let cardData: Card
+    let pointColor: Color
+    let firstLookHandler: () -> Void
+    
+    var body: some View {
+        ZStack {
+            Color.semanticColor.background_dimmed
+                .ignoresSafeArea()
+                .onTapGesture {
+                    isPresented = false
+                }
+            
+            VStack(spacing: 0) {
+                
+                CarouselCard(card: cardData, index: index, pointColor: pointColor, isShareEnabled: true)
+                    .frame(width: Metric.cardWidth, height: Metric.cardHeight)
+                
+                Button {
+                    if UserActionHistory.isFirstLook == false {
+                        UserActionHistory.isFirstLook = true
+                        firstLookHandler()
+                    }
+                    isPresented = false
+                } label: {
+                    Image("xbutton")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: Metric.xButtonSize, height: Metric.xButtonSize)
+                }
+                .padding(.top, 43)
+            }
+        }
+    }
+}
+
+#Preview {
+    SingleModalView(
+        isPresented: .constant(true),
+        index: 0,
+        cardData: .stub(),
+        pointColor: ColorPalette.pointOrange500,
+        firstLookHandler: {}
+    )
+}

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/Component/RecommendCardCell.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/Component/RecommendCardCell.swift
@@ -71,7 +71,6 @@ struct RecommendCardCell: View {
             .padding(.leading, Metric.commonPadding)
             
             VStack(spacing: 0) {
-                // testURL: https://picsum.photos/400/300
                 CachedAsyncImage(url: props.imageURL ?? "") {
                     placeHolder(kind: props.kind)
                 }

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/Component/RecommendCardCell.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/Component/RecommendCardCell.swift
@@ -1,0 +1,107 @@
+//
+//  RecommendCardCell.swift
+//  NewsLetter
+//
+//  Created by 이원빈 on 4/27/26.
+//
+
+import SwiftUI
+
+
+struct RecommendCardCellProps {
+    let title: String
+    let job: String
+    let source: String
+    let kind: Kind
+    let colorSet: COLORSET
+    
+    enum Kind: String {
+        case news
+        case blog
+        case book
+    }
+}
+
+extension RecommendCardCellProps {
+    static func stub(title: String = "가나다라마바사아자차카타파하가나다라마바사아자차카타파하",
+                     job: String = "직군",
+                     source: String = "출처",
+                     kind: Kind = .blog,
+                     colorSet: COLORSET = COLORSET_LIST.first!) -> Self {
+        .init(title: title,
+              job: job,
+              source: source,
+              kind: kind,
+              colorSet: colorSet)
+    }
+}
+
+struct RecommendCardCell: View {
+    private enum Metric {
+        static let commonPadding: CGFloat = 24
+    }
+    
+    let props: RecommendCardCellProps
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(props.title)
+                .font(.body18_bold)
+                .foregroundStyle(ColorPalette.gray950)
+                .padding(.top, Metric.commonPadding)
+                .padding(.horizontal, Metric.commonPadding)
+            
+            HStack(spacing: 0) {
+                Text(props.job)
+                    .font(.body13_medium)
+                    .foregroundStyle(ColorPalette.gray950.opacity(0.5))
+                    .padding(.trailing, 6)
+                Rectangle()
+                    .frame(width: 1, height: 14)
+                    .foregroundStyle(ColorPalette.black.opacity(0.1))
+                    .padding(.trailing, 6)
+                Text(props.source)
+                    .font(.body13_medium)
+                    .foregroundStyle(ColorPalette.gray950.opacity(0.5))
+            }
+            .padding(.top, 4)
+            .padding(.leading, Metric.commonPadding)
+            
+            VStack(spacing: 0) {
+                // testURL: https://picsum.photos/400/300
+                CachedAsyncImage(url: "") {
+                    placeHolder(kind: .news)
+                }
+                .aspectRatio(contentMode: .fill)
+                .frame(maxWidth: .infinity, maxHeight: 150)
+            }
+            .background(RoundedRectangle(cornerRadius: 16).foregroundStyle(ColorPalette.white.opacity(0.3)))
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+            .padding(.top, 20)
+            .padding(.horizontal, Metric.commonPadding)
+            .padding(.bottom, 34)
+                
+        }
+        .background(RoundedRectangle(cornerRadius: 12).foregroundStyle(props.colorSet.main))
+    }
+    
+    @ViewBuilder
+    private func placeHolder(kind: RecommendCardCellProps.Kind) -> some View {
+        VStack(spacing: 0) {
+            Text(kind.rawValue.uppercased())
+                .font(.system(size: 48, weight: .black))
+                .padding(.top, 46)
+                .frame(maxWidth: .infinity)
+                .foregroundStyle(props.colorSet.sub)
+            Rectangle()
+                .frame(width: 48, height: 4)
+                .padding(.top, 4)
+                .padding(.bottom, 48)
+                .foregroundStyle(props.colorSet.sub)
+        }
+    }
+}
+
+#Preview {
+    RecommendCardCell(props: .stub())
+}

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/Component/RecommendCardCell.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/Component/RecommendCardCell.swift
@@ -14,7 +14,7 @@ struct RecommendCardCellProps {
     let source: String
     let imageURL: String?
     let kind: Card.Kind
-    let colorSet: COLORSET
+    let colorSet: ColorSet
 }
 
 extension RecommendCardCellProps {
@@ -23,7 +23,7 @@ extension RecommendCardCellProps {
                      source: String = "출처",
                      imageURL: String? = nil,
                      kind: Card.Kind = .blog,
-                     colorSet: COLORSET = COLORSET_LIST.first!) -> Self {
+                     colorSet: ColorSet = defaultColorSet.first!) -> Self {
         .init(title: title,
               job: job,
               source: source,

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/Component/RecommendCardCell.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/Component/RecommendCardCell.swift
@@ -12,6 +12,7 @@ struct RecommendCardCellProps {
     let title: String
     let job: String
     let source: String
+    let imageURL: String?
     let kind: Kind
     let colorSet: COLORSET
     
@@ -26,11 +27,13 @@ extension RecommendCardCellProps {
     static func stub(title: String = "가나다라마바사아자차카타파하가나다라마바사아자차카타파하",
                      job: String = "직군",
                      source: String = "출처",
+                     imageURL: String? = nil,
                      kind: Kind = .blog,
                      colorSet: COLORSET = COLORSET_LIST.first!) -> Self {
         .init(title: title,
               job: job,
               source: source,
+              imageURL: imageURL,
               kind: kind,
               colorSet: colorSet)
     }
@@ -69,7 +72,7 @@ struct RecommendCardCell: View {
             
             VStack(spacing: 0) {
                 // testURL: https://picsum.photos/400/300
-                CachedAsyncImage(url: "") {
+                CachedAsyncImage(url: props.imageURL ?? "") {
                     placeHolder(kind: .news)
                 }
                 .aspectRatio(contentMode: .fill)

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/Component/RecommendCardCell.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/Component/RecommendCardCell.swift
@@ -73,7 +73,7 @@ struct RecommendCardCell: View {
             VStack(spacing: 0) {
                 // testURL: https://picsum.photos/400/300
                 CachedAsyncImage(url: props.imageURL ?? "") {
-                    placeHolder(kind: .news)
+                    placeHolder(kind: props.kind)
                 }
                 .aspectRatio(contentMode: .fill)
                 .frame(maxWidth: .infinity, maxHeight: 150)

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/Component/RecommendCardCell.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/Component/RecommendCardCell.swift
@@ -13,14 +13,8 @@ struct RecommendCardCellProps {
     let job: String
     let source: String
     let imageURL: String?
-    let kind: Kind
+    let kind: Card.Kind
     let colorSet: COLORSET
-    
-    enum Kind: String {
-        case news
-        case blog
-        case book
-    }
 }
 
 extension RecommendCardCellProps {
@@ -28,7 +22,7 @@ extension RecommendCardCellProps {
                      job: String = "직군",
                      source: String = "출처",
                      imageURL: String? = nil,
-                     kind: Kind = .blog,
+                     kind: Card.Kind = .blog,
                      colorSet: COLORSET = COLORSET_LIST.first!) -> Self {
         .init(title: title,
               job: job,
@@ -88,7 +82,7 @@ struct RecommendCardCell: View {
     }
     
     @ViewBuilder
-    private func placeHolder(kind: RecommendCardCellProps.Kind) -> some View {
+    private func placeHolder(kind: Card.Kind) -> some View {
         VStack(spacing: 0) {
             Text(kind.rawValue.uppercased())
                 .font(.system(size: 48, weight: .black))

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/RecommendReducer.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/RecommendReducer.swift
@@ -27,7 +27,7 @@ struct RecommendReducer {
         }
         
         var cardData: [Card] = []
-        var cardColors: [COLORSET] = []
+        var cardColors: [ColorSet] = []
         var isPresentModal: Bool = false
         var isRefreshLoading: Bool = false
     }
@@ -39,7 +39,7 @@ struct RecommendReducer {
         case refreshButtonPressed
         case tick
         case startTimer
-        case setColorPalette([COLORSET])
+        case setColorPalette([ColorSet])
         case fetchCards
         case loginUser
         case registerUser
@@ -89,7 +89,7 @@ struct RecommendReducer {
                         UserActionHistory.isChangedCareer = false
                     } else {
                         state.cardData = cachedCards
-                        state.cardColors = COLORSET_LIST
+                        state.cardColors = cachedCards.colorSet
                     }
                     
                 } else {
@@ -218,7 +218,7 @@ struct RecommendReducer {
                 }
 
                 UserInfo.lastCardFetchDate = Date()
-                return .send(.setColorPalette(COLORSET_LIST))
+                return .send(.setColorPalette(cards.colorSet))
             case .setIsPresentModal(let bool):
                 state.isPresentModal = bool
                 return .none

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/RecommendReducer.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/RecommendReducer.swift
@@ -27,8 +27,9 @@ struct RecommendReducer {
         }
         
         var cardData: [Card] = []
-        var cardColors: [Color] = []
+        var cardColors: [COLORSET] = []
         var isPresentModal: Bool = false
+        var isRefreshLoading: Bool = false
     }
     
     enum Action: BindableAction {
@@ -38,7 +39,7 @@ struct RecommendReducer {
         case refreshButtonPressed
         case tick
         case startTimer
-        case setColorPalette([Color])
+        case setColorPalette([COLORSET])
         case fetchCards
         case loginUser
         case registerUser
@@ -46,6 +47,7 @@ struct RecommendReducer {
         case setCards([Card])
         case delegate(Delegate)
         case setIsPresentModal(Bool)
+        case setIsRefreshLoading(Bool)
         
         @CasePathable
         enum Delegate {
@@ -80,16 +82,14 @@ struct RecommendReducer {
                 
                 if todayString == lastVisitString ,
                    let cachedCards = UserInfo.cachedDailyCards,
-                   !cachedCards.isEmpty,
-                   let cachedColors = UserInfo.cachedDailyColors?.map({ $0.color }),
-                   !cachedColors.isEmpty {
+                   !cachedCards.isEmpty {
                     
                     if UserActionHistory.isChangedCareer == true {
                         effects.append(.send(.fetchCards))
                         UserActionHistory.isChangedCareer = false
                     } else {
                         state.cardData = cachedCards
-                        state.cardColors = cachedColors
+                        state.cardColors = COLORSET_LIST
                     }
                     
                 } else {
@@ -116,11 +116,15 @@ struct RecommendReducer {
             case .refreshButtonPressed:
                 return .run { send in
                     do {
+                        await send(.setIsRefreshLoading(true))
                         let userId = String(UserInfo.userId ?? 3)
                         try await cardClient.refreshCards(RefreshCardsRequestDTO(userId: userId))
+                        try await clock.sleep(for: .seconds(1))  // ← 서버 처리 대기
                         await send(.fetchCards)
+                        await send(.setIsRefreshLoading(false))
                         UserActionHistory.useRefreshDate = Date()
                     } catch let error {
+                        await send(.setIsRefreshLoading(false))
                         print(error.localizedDescription)
                         guard let error = error as? MoyaError else { return }
                         
@@ -149,7 +153,6 @@ struct RecommendReducer {
                     
                     UserInfo.lastCardFetchDate = nil
                     UserInfo.cachedDailyCards = nil
-                    UserInfo.cachedDailyColors = nil
                     
                     return .send(.fetchCards)
                 }
@@ -213,24 +216,14 @@ struct RecommendReducer {
                 if cards.isEmpty {
                     return .none
                 }
-                
+
                 UserInfo.lastCardFetchDate = Date()
-                
-                let fixedColors: [Color] = [
-                    ColorPalette.pointPurple200,
-                    ColorPalette.pointOrange400,
-                    ColorPalette.pointBlue300,
-                    ColorPalette.pointLemonYellow300,
-                    ColorPalette.pointPink300,
-                    ColorPalette.pointGreen300
-                ]
-                
-                let colorNames = fixedColors.compactMap { ColorPaletteName.from(color: $0) }
-                UserInfo.cachedDailyColors = colorNames
-                
-                return .send(.setColorPalette(fixedColors))
+                return .send(.setColorPalette(COLORSET_LIST))
             case .setIsPresentModal(let bool):
                 state.isPresentModal = bool
+                return .none
+            case .setIsRefreshLoading(let bool):
+                state.isRefreshLoading = bool
                 return .none
             case .delegate:
                 return .none

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/RecommendView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/RecommendView.swift
@@ -116,7 +116,7 @@ struct RecommendView: View {
                         job: data.topKeyword,
                         source: data.newsletterName,
                         imageURL: data.imageURL,
-                        kind: data.cardType.toDomain(),
+                        kind: data.kind,
                         colorSet: store.cardColors[index]
                     )
                     RecommendCardCell(props: props)

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/RecommendView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/RecommendView.swift
@@ -25,15 +25,6 @@ struct RecommendView: View {
     
     @State private var cardTapCount: Int = 0
     @State private var scrolledID: Int?
-    @State private var isJumping = false // 무한 스크롤을 위해 position 점프를 하고있는 중인지 여부
-    
-    // 배열 인덱스 → 실제 카드 인덱스 매핑
-    // loopedCards: [3, 0, 1, 2, 3, 0] (stubCards 기준 인덱스)
-    private var loopedCardIndices: [Int] {
-        let count = store.cardData.count
-        guard count > 0 else { return [] }
-        return [count - 1] + Array(0..<count) + [0]
-    }
     
     var showRefreshButton: Bool {
         guard let refreshDate = UserActionHistory.useRefreshDate else { return true }
@@ -119,30 +110,33 @@ struct RecommendView: View {
     private var cardCarousel: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: -80) {
-                ForEach(Array(loopedCardIndices.enumerated()), id: \.offset) { position, cardIndex in
-                    let data = store.cardData[cardIndex]
+                ForEach(Array(store.cardData.enumerated()), id: \.offset) { index, data in
                     let props = RecommendCardCellProps(
                         title: data.title,
                         job: data.topKeyword,
                         source: data.newsletterName,
                         imageURL: data.imageURL,
-                        kind: .blog,
-                        colorSet: store.cardColors[cardIndex]
+                        kind: data.cardType.toDomain(),
+                        colorSet: store.cardColors[index]
                     )
                     RecommendCardCell(props: props)
                         .frame(width: Metric.cardWidth)
-                        .scaleEffect(scrolledID == position ? 1 : 0.7)
-                        .blur(radius: scrolledID == position ? 0 : 2)
+                        .scaleEffect(scrolledID == index ? 1 : 0.7)
+                        .blur(radius: scrolledID == index ? 0 : 2)
                         .rotation3DEffect(
-                            .degrees(cardRotationDegree(for: position)),
+                            .degrees(cardRotationDegree(for: index)),
                             axis: (x: 0, y: 1, z: 0),
                             perspective: 0.5
                         )
-                        .zIndex(position == scrolledID ? 2 : 1)
-                        .id(position)
+                        .zIndex(index == scrolledID ? 2 : 1)
+                        .id(index)
                         .onTapGesture {
-                            GA.click_newsletter(title: data.title, listIndex: position)
-                            selectedIndex = cardIndex
+                            guard scrolledID == index else {
+                                scrolledID = index
+                                return
+                            }
+                            GA.click_newsletter(title: data.title, listIndex: index)
+                            selectedIndex = index
                             cardTapHandler()
                         }
                 }
@@ -152,30 +146,9 @@ struct RecommendView: View {
         .contentMargins(.horizontal, Metric.scrollHorizontalMargin, for: .scrollContent)
         .scrollPosition(id: $scrolledID, anchor: .center)
         .scrollTargetBehavior(.viewAligned)
-        .transaction { t in
-            if isJumping {
-                t.disablesAnimations = true
-            }
-        }
         .onAppear {
             if scrolledID == nil {
-                scrolledID = 1
-            }
-        }
-        .onChange(of: scrolledID) { _, newValue in
-            guard let newValue else { return }
-            let count = store.cardData.count
-            guard count > 0 else { return }
-            let lastIndex = count + 1
-            
-            if newValue == 0 {
-                isJumping = true
-                scrolledID = count
-                DispatchQueue.main.async { isJumping = false }
-            } else if newValue == lastIndex {
-                isJumping = true
-                scrolledID = 1
-                DispatchQueue.main.async { isJumping = false }
+                scrolledID = 0
             }
         }
     }
@@ -183,7 +156,7 @@ struct RecommendView: View {
     private var indicator: some View {
         HStack(spacing: Metric.indicatorSize) {
             ForEach(0..<store.cardData.count, id: \.self) { index in
-                let isFocused = index + 1 == scrolledID
+                let isFocused = index == scrolledID
                 RoundedRectangle(cornerRadius: 8)
                     .fill(isFocused ? Color.black : Color.gray.opacity(0.5))
                     .frame(
@@ -192,7 +165,7 @@ struct RecommendView: View {
                     )
                     .animation(.easeInOut, value: scrolledID)
                     .onTapGesture {
-                        scrolledID = index + 1
+                        scrolledID = index
                     }
             }
         }

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/RecommendView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/RecommendView.swift
@@ -125,6 +125,7 @@ struct RecommendView: View {
                         title: data.title,
                         job: data.topKeyword,
                         source: data.newsletterName,
+                        imageURL: data.imageURL,
                         kind: .blog,
                         colorSet: store.cardColors[cardIndex]
                     )

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/RecommendView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/RecommendView.swift
@@ -11,24 +11,29 @@ import ComposableArchitecture
 import FirebaseAnalytics
 
 struct RecommendView: View {
-    @Bindable var store: StoreOf<RecommendReducer>
-    @Binding var selectedIndex: Int?
-    
+    private enum Metric {
+        static let cardWidth: CGFloat = UIScreen.main.bounds.width * 0.8
+        static let scrollHorizontalMargin: CGFloat = (UIScreen.main.bounds.width - cardWidth) / 2
+        static let indicatorSize: CGFloat = 8
+        static let indicatorHilightedSize: CGFloat = 22
+    }
     @Environment(\.scenePhase) private var scenePhase
     
+    @Bindable var store: StoreOf<RecommendReducer>
+    
+    @Binding var selectedIndex: Int?
+    
     @State private var cardTapCount: Int = 0
-    @State private var pulseOffsets: [Int: CGFloat] = [:]
-    @State private var didAnimateSlot: Set<Int> = []
+    @State private var scrolledID: Int?
+    @State private var isJumping = false // 무한 스크롤을 위해 position 점프를 하고있는 중인지 여부
     
-    @State private var start: Int = 0
-    @State private var scrollAccum: CGFloat = 0
-    @State private var progress: CGFloat = 0
-    @State private var lastDragTranslation: CGFloat = 0
-    @State private var isDragging: Bool = false
-    @State private var cardHeights: [CGFloat] = []
-    @State private var isCardAnimating: Bool = false
-    
-    let cardTypes: [CardType] = [.one, .two, .three, .four, .five, .six]
+    // 배열 인덱스 → 실제 카드 인덱스 매핑
+    // loopedCards: [3, 0, 1, 2, 3, 0] (stubCards 기준 인덱스)
+    private var loopedCardIndices: [Int] {
+        let count = store.cardData.count
+        guard count > 0 else { return [] }
+        return [count - 1] + Array(0..<count) + [0]
+    }
     
     var showRefreshButton: Bool {
         guard let refreshDate = UserActionHistory.useRefreshDate else { return true }
@@ -36,80 +41,18 @@ struct RecommendView: View {
     }
     
     var body: some View {
-        ZStack(alignment: .bottom) {
-            VStack(spacing: 0) {
-                Spacer()
-                
-                if store.state.cardData.count > 0 {
-                    Image("bg_drawers")
-                        .resizable()
-                        .frame(width: 600, height: UIDevice.isSmallScreen ? Device.height * 0.75 : Device.height * 0.65)
-                        .padding(.bottom, Device.safeAreaInsets.bottom)
-                }
-            }
-            .allowsHitTesting(false)
-            
-            cardsStack
-                .padding(.bottom, -20)
-                .frame(width: Device.width)
-                .contentShape(Rectangle())
-                .simultaneousGesture(cardScrollGesture)
-            
-            VStack(spacing: 8) {
-                Text(store.state.todayDate)
-                    .fontRangeLimited()
-                    .font(UIDevice.isSmallScreen || UIDevice.is13MiniScreen ? .jalnanGothicSE : .jalnanGothic)
-                    .multilineTextAlignment(.center)
-                    .foregroundColor(.semanticColor.text_strong)
-                    .frame(maxWidth: .infinity, alignment: .center)
-                    .padding(.top, UIDevice.isSmallScreen ? 4 : 12)
-                    .fixedSize(horizontal: false, vertical: true)
-                
-                Text("뉴스레터는 매일 새롭게 업데이트 돼요")
-                    .fontRangeLimited()
-                    .font(.body15_semiBold)
-                    .foregroundColor(.semanticColor.text_strong)
-                
-                HStack(spacing: 0) {
-                    Text("아래 뉴스는 ")
-                        .font(.body15_medium)
-                        .foregroundColor(.semanticColor.text_secondary)
-                    Text(store.state.formattedTime)
-                        .fontRangeLimited()
-                        .font(.body16_semiBold)
-                        .foregroundColor(.semanticColor.state_negative_primary)
-                    Text(" 동안 볼 수 있어요")
-                        .font(.body15_medium)
-                        .foregroundColor(.semanticColor.text_secondary)
-                }
-                
-                Button {
-                    store.send(.refreshButtonPressed)
-                } label: {
-                    HStack(spacing: 4) {
-                        Image("icon-sync-mono")
-                            .renderingMode(.template)
-                            .resizable()
-                            .frame(width: 16, height: 16)
-                            .foregroundStyle(showRefreshButton ? .semanticColor.text_secondary : .semanticColor.text_disabled)
-                        
-                        Text("새로고침 (\(showRefreshButton ? 0 : 1)/1)")
-                            .font(.body14_semiBold)
-                            .foregroundColor(showRefreshButton ? .semanticColor.text_secondary : .semanticColor.text_disabled)
-                    }
-                    .padding(.vertical, 6)
-                    .padding(.horizontal, 12)
-                    .background(
-                        RoundedRectangle(cornerRadius: 20)
-                            .foregroundColor(showRefreshButton ? .semanticColor.fill_primary : .clear)
-                    )
-                }
-                .disabled(!showRefreshButton)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        VStack(spacing: 0) {
+            headerSection
+            refreshButton
+                .padding(.top, 12)
+            cardCarousel
+                .padding(.top, 80)
+            indicator
+                .padding(.top, 40)
+            Spacer()
         }
         .animation(.easeInOut, value: store.isPresentModal)
-        .ignoresSafeArea(edges: .all)
+        .animation(.smooth, value: scrolledID)
         .transition(.opacity)
         .onAppear {
             GA.pageview_main()
@@ -131,8 +74,6 @@ struct RecommendView: View {
                     DateCalculator.isCanShowNotificationPermissionBottomSheet()
             else { return }
             store.send(.delegate(.presentNotificationPermissionBottomSheet(true)))
-            
-            initializeCardHeights()
         }
         .onDisappear {
             store.send(.onDisappear)
@@ -144,232 +85,148 @@ struct RecommendView: View {
         }
     }
     
-    @ViewBuilder
-    private var cardsStack: some View {
-        let count = min(cardTypes.count, store.state.cardData.count)
-        if count == 0 {
-            EmptyView()
-        } else {
-            GeometryReader { geometry in
-                ZStack {
-                    if progress > 0, count > 0 {
-                        let dataIndex = feedIndex(for: count - 1, count: count)
-                        phantomCardView(
-                            dataIndex: dataIndex,
-                            targetSlot: 0,
-                            positionY: cardPositionY(at: 1) - progress * cardStep - 10,
-                            zIndex: -1
+    private var headerSection: some View {
+        VStack(spacing: 8) {
+            Text(store.state.todayDate)
+                .fontRangeLimited()
+                .font(UIDevice.isSmallScreen || UIDevice.is13MiniScreen ? .jalnanGothicSE : .jalnanGothic)
+                .multilineTextAlignment(.center)
+                .foregroundColor(.semanticColor.text_strong)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.top, UIDevice.isSmallScreen ? 4 : 12)
+                .fixedSize(horizontal: false, vertical: true)
+            
+            Text("뉴스레터는 매일 새롭게 업데이트 돼요")
+                .fontRangeLimited()
+                .font(.body15_semiBold)
+                .foregroundColor(.semanticColor.text_strong)
+            
+            HStack(spacing: 0) {
+                Text("아래 뉴스는 ")
+                    .font(.body15_medium)
+                    .foregroundColor(.semanticColor.text_secondary)
+                Text(store.state.formattedTime)
+                    .fontRangeLimited()
+                    .font(.body16_semiBold)
+                    .foregroundColor(.semanticColor.state_negative_primary)
+                Text(" 동안 볼 수 있어요")
+                    .font(.body15_medium)
+                    .foregroundColor(.semanticColor.text_secondary)
+            }
+        }
+    }
+    
+    private var cardCarousel: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: -80) {
+                ForEach(Array(loopedCardIndices.enumerated()), id: \.offset) { position, cardIndex in
+                    let data = store.cardData[cardIndex]
+                    let props = RecommendCardCellProps(
+                        title: data.title,
+                        job: data.topKeyword,
+                        source: data.newsletterName,
+                        kind: .blog,
+                        colorSet: store.cardColors[cardIndex]
+                    )
+                    RecommendCardCell(props: props)
+                        .frame(width: Metric.cardWidth)
+                        .scaleEffect(scrolledID == position ? 1 : 0.7)
+                        .blur(radius: scrolledID == position ? 0 : 2)
+                        .rotation3DEffect(
+                            .degrees(cardRotationDegree(for: position)),
+                            axis: (x: 0, y: 1, z: 0),
+                            perspective: 0.5
                         )
-                    }
-                    
-                    ForEach(0..<count, id: \.self) { slot in
-                        let dataIndex = feedIndex(for: slot, count: count)
-                        let item = store.state.cardData[dataIndex]
-                        
-                        let currentDepth = CGFloat(slot) + progress
-                        let style = interpolatedStyle(depth: currentDepth)
-                        
-                        let translationY = calculateTranslationY(for: slot, count: count)
-                        
-                        CardView(
-                            style: style,
-                            color: store.cardColors[dataIndex],
-                            title: item.title,
-                            category: item.topKeyword,
-                            source: item.newsletterName,
-                            shouldMoveY: ((Device.height - 477) / 2) + 180 - cardPositionY(at: slot) - 90,
-                            onTap: {
-                                guard !isDragging else { return }
-                                selectedIndex = dataIndex
-                                cardTapHandler()
-                                GA.click_newsletter(title: item.title, listIndex: count - 1 - dataIndex)
-                            },
-                            onTapBegan: {
-                                lockCardScrollForTapAnimation()
-                            },
-                            isPresentModal: $store.isPresentModal
-                        )
-                        .position(
-                            x: Device.width / 2,
-                            y: cardPositionY(at: slot) + translationY
-                        )
-                        .offset(y: pulseOffsets[slot] ?? 0)
-                        .zIndex(Double(slot))
-                        .onAppear {
-                            guard !didAnimateSlot.contains(slot) else { return }
-                            didAnimateSlot.insert(slot)
-                            
-                            let playOrder = (count - 1) - slot
-                            let delayMs = playOrder * 150
-                            
-                            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(delayMs)) {
-                                withAnimation(.easeInOut(duration: 0.2)) {
-                                    pulseOffsets[slot] = -5
-                                }
-                                DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200)) {
-                                    withAnimation(.easeInOut(duration: 0.1)) {
-                                        pulseOffsets[slot] = 0
-                                    }
-                                }
-                            }
+                        .zIndex(position == scrolledID ? 2 : 1)
+                        .id(position)
+                        .onTapGesture {
+                            GA.click_newsletter(title: data.title, listIndex: position)
+                            selectedIndex = cardIndex
+                            cardTapHandler()
                         }
-                    }
-                    
-                    if progress < 0, count > 0 {
-                        let lastSlot = count - 1
-                        let dataIndex = feedIndex(for: 0, count: count)
-                        phantomCardView(
-                            dataIndex: dataIndex,
-                            targetSlot: lastSlot,
-                            positionY: cardPositionY(at: lastSlot) + cardStep + progress * cardStep + 10,
-                            zIndex: 5
-                        )
-                    }
                 }
+            }
+            .scrollTargetLayout()
+        }
+        .contentMargins(.horizontal, Metric.scrollHorizontalMargin, for: .scrollContent)
+        .scrollPosition(id: $scrolledID, anchor: .center)
+        .scrollTargetBehavior(.viewAligned)
+        .transaction { t in
+            if isJumping {
+                t.disablesAnimations = true
+            }
+        }
+        .onAppear {
+            if scrolledID == nil {
+                scrolledID = 1
+            }
+        }
+        .onChange(of: scrolledID) { _, newValue in
+            guard let newValue else { return }
+            let count = store.cardData.count
+            guard count > 0 else { return }
+            let lastIndex = count + 1
+            
+            if newValue == 0 {
+                isJumping = true
+                scrolledID = count
+                DispatchQueue.main.async { isJumping = false }
+            } else if newValue == lastIndex {
+                isJumping = true
+                scrolledID = 1
+                DispatchQueue.main.async { isJumping = false }
             }
         }
     }
     
-    private var cardScrollGesture: AnyGesture<DragGesture.Value> {
-        if isScrollLocked {
-            return AnyGesture(DragGesture(minimumDistance: .infinity))
-        }
-        
-        return AnyGesture(
-            DragGesture(minimumDistance: 5)
-                .onChanged { value in
-                    isDragging = true
-                    let delta = value.translation.height - lastDragTranslation
-                    lastDragTranslation = value.translation.height
-                    scrollAccum += delta
-                    
-                    let step = cardStep
-                    let count = min(cardTypes.count, store.state.cardData.count)
-                    guard count > 0 else { return }
-                    
-                    while scrollAccum >= step {
-                        start = (start + 1) % count
-                        scrollAccum -= step
+    private var indicator: some View {
+        HStack(spacing: Metric.indicatorSize) {
+            ForEach(0..<store.cardData.count, id: \.self) { index in
+                let isFocused = index + 1 == scrolledID
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(isFocused ? Color.black : Color.gray.opacity(0.5))
+                    .frame(
+                        width: isFocused ? Metric.indicatorHilightedSize : Metric.indicatorSize,
+                        height: Metric.indicatorSize
+                    )
+                    .animation(.easeInOut, value: scrolledID)
+                    .onTapGesture {
+                        scrolledID = index + 1
                     }
-                    
-                    while scrollAccum <= -step {
-                        start = (start - 1 + count) % count
-                        scrollAccum += step
-                    }
-                    
-                    progress = scrollAccum / step
-                }
-                .onEnded { _ in
-                    lastDragTranslation = 0
-                    withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
-                        scrollAccum = 0
-                        progress = 0
-                    }
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-                        isDragging = false
-                    }
-                }
-        )
-    }
-    
-    private var isScrollLocked: Bool {
-        isCardAnimating || store.isPresentModal
-    }
-    
-    private func lockCardScrollForTapAnimation() {
-        guard isCardAnimating == false else { return }
-        isCardAnimating = true
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + CardView.tapAnimationTotalDuration) {
-            isCardAnimating = false
-        }
-    }
-    
-    @ViewBuilder
-    private func phantomCardView(
-        dataIndex: Int,
-        targetSlot: Int,
-        positionY: CGFloat,
-        zIndex: Double
-    ) -> some View {
-        let item = store.state.cardData[dataIndex]
-        let style = interpolatedStyle(depth: CGFloat(targetSlot))
-        
-        CardView(
-            style: style,
-            color: store.cardColors[dataIndex],
-            title: item.title,
-            category: item.topKeyword,
-            source: item.newsletterName,
-            shouldMoveY: ((Device.height - 477) / 2) + 180 - cardPositionY(at: targetSlot) - 90,
-            onTap: {
-                guard !isDragging else { return }
-                selectedIndex = dataIndex
-                cardTapHandler()
-            },
-            onTapBegan: {
-                lockCardScrollForTapAnimation()
-            },
-            isPresentModal: $store.isPresentModal
-        )
-        .position(x: Device.width / 2, y: positionY)
-        .zIndex(zIndex)
-    }
-    
-    private func initializeCardHeights() {
-        let count = min(cardTypes.count, store.state.cardData.count)
-        guard count > 0 else { return }
-        
-        cardHeights = (0..<count).map { index in
-            if index == 0 { return 0 }
-            return cardPositionY(at: index) - cardPositionY(at: index - 1)
-        }
-    }
-    
-    private func getCardHeightDiff(at index: Int) -> CGFloat {
-        guard index >= 0 && index < cardHeights.count else { return cardStep }
-        return cardHeights[index]
-    }
-    
-    private func calculateTranslationY(for slot: Int, count: Int) -> CGFloat {
-        if progress < 0 {
-            if slot == 0 {
-                return -progress * 20
-            } else {
-                return progress * cardStep
-            }
-        } else {
-            if slot == count - 1 {
-                return progress * cardStep
-            } else {
-                let dataIndex = feedIndex(for: slot, count: count)
-                let nextIndex = min(dataIndex + 1, count - 1)
-                return getCardHeightDiff(at: nextIndex) * progress
             }
         }
     }
     
-    private func feedIndex(for slot: Int, count: Int) -> Int {
-        (slot - start + count) % count
-    }
-    
-    private var cardStep: CGFloat {
-        if UIDevice.isSmallScreen { return 80 }
-        if UIDevice.is13MiniScreen { return 83 }
-        if UIDevice.isLargeScreen { return 95 }
-        return 90
-    }
-    
-    private func cardPositionY(at index: Int) -> CGFloat {
-        if UIDevice.isSmallScreen {
-            return Device.height - 430 + CGFloat(index * 80) - 100
-        } else if UIDevice.is13MiniScreen {
-            return Device.height - 455 + CGFloat(index * 83) - 100
-        } else if UIDevice.isLargeScreen {
-            return Device.height - 530 + CGFloat(index * 95) - 100
-        } else {
-            return Device.height - 490 + CGFloat(index * 90) - 100
+    var refreshButton: some View {
+        Button {
+            store.send(.refreshButtonPressed)
+        } label: {
+            HStack(spacing: 4) {
+                if store.isRefreshLoading {
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                        .tint(.semanticColor.text_secondary)
+                        .frame(width: 16, height: 16)
+                } else {
+                    Image("icon-sync-mono")
+                        .renderingMode(.template)
+                        .resizable()
+                        .frame(width: 16, height: 16)
+                        .foregroundStyle(showRefreshButton ? .semanticColor.text_secondary : .semanticColor.text_disabled)
+                }
+
+                Text("새로고침 (\(showRefreshButton ? 0 : 1)/1)")
+                    .font(.body14_semiBold)
+                    .foregroundColor(showRefreshButton ? .semanticColor.text_secondary : .semanticColor.text_disabled)
+            }
+            .padding(.vertical, 6)
+            .padding(.horizontal, 12)
+            .background(
+                RoundedRectangle(cornerRadius: 20)
+                    .foregroundColor(showRefreshButton ? .semanticColor.fill_primary : .clear)
+            )
         }
+        .disabled(!showRefreshButton || store.isRefreshLoading)
     }
     
     private func cardTapHandler() {
@@ -391,6 +248,20 @@ struct RecommendView: View {
             }
         }
         cardTapCount += 1
+    }
+    
+    private func cardRotationDegree(for position: Int) -> Double {
+        guard let scrolledID else { return 0 }
+        let isPrevCard = position == scrolledID - 1
+        let isNextCard = position == scrolledID + 1
+        
+        if isPrevCard {
+            return 20
+        }
+        if isNextCard {
+            return -20
+        }
+        return 0
     }
 }
 

--- a/NewsLetter/NewsLetter/Source/Data/Client/CardClient.swift
+++ b/NewsLetter/NewsLetter/Source/Data/Client/CardClient.swift
@@ -32,21 +32,8 @@ extension CardClient: DependencyKey {
             return CardClient(
                 fetchCards: { requestDTO in
                     let response = try await apiClient.request(CardAPI.fetchCards(requestDTO))
-
-                    let cardResponse = try response.map(CardResponseDTO.self)
-                    let cards = cardResponse.cards.map { cardDTO in
-                        Card(
-                            id: cardDTO.id,
-                            title: cardDTO.title,
-                            topKeyword: cardDTO.topKeyword,
-                            summary: cardDTO.summary,
-                            contentURL: cardDTO.contentURL,
-                            imageURL: cardDTO.imageURL,
-                            newsletterName: cardDTO.newsletterName,
-                            language: cardDTO.language
-                        )
-                    }
-                    return cards
+                    let cardResponseDTO = try response.map(CardResponseDTO.self)
+                    return cardResponseDTO.toDomain()
                 },
                 fetchExploreCards: { requestDTO in
                     let response = try await apiClient.request(CardAPI.fetchExploreCard(requestDTO))
@@ -68,12 +55,12 @@ extension CardClient: DependencyKey {
         return CardClient(
             fetchCards: { _ in
                 return [
-                    Card(id: 1192, title: "Preview Title 1", topKeyword: "Preview Keyword 1", summary: "Preview Summary 1", contentURL: "https://example.com", imageURL: nil, newsletterName: "Preview Newsletter 1", language: "ENGLISH"),
-                    Card(id: 1201, title: "Preview Title 2", topKeyword: "Preview Keyword 2", summary: "Preview Summary 2", contentURL: "https://example.com", imageURL: nil, newsletterName: "Preview Newsletter 2", language: "ENGLISH"),
-                    Card(id: 1170, title: "Preview Title 3", topKeyword: "Preview Keyword 3", summary: "Preview Summary 3", contentURL: "https://example.com", imageURL: nil, newsletterName: "Preview Newsletter 3", language: "ENGLISH"),
-                    Card(id: 1123, title: "Preview Title 4", topKeyword: "Preview Keyword 4", summary: "Preview Summary 4", contentURL: "https://example.com", imageURL: nil, newsletterName: "Preview Newsletter 4", language: "ENGLISH"),
-                    Card(id: 1148, title: "Preview Title 5", topKeyword: "Preview Keyword 5", summary: "Preview Summary 5", contentURL: "https://example.com", imageURL: nil, newsletterName: "Preview Newsletter 5", language: "ENGLISH"),
-                    Card(id: 938, title: "Preview Title 6", topKeyword: "Preview Keyword 6", summary: "Preview Summary 6", contentURL: "https://example.com", imageURL: nil, newsletterName: "Preview Newsletter 6", language: "ENGLISH")
+                    Card(id: 1192, title: "Preview Title 1", topKeyword: "Preview Keyword 1", summary: "Preview Summary 1", contentURL: "https://example.com", imageURL: nil, newsletterName: "Preview Newsletter 1", language: "ENGLISH", cardType: .blog),
+                    Card(id: 1201, title: "Preview Title 2", topKeyword: "Preview Keyword 2", summary: "Preview Summary 2", contentURL: "https://example.com", imageURL: nil, newsletterName: "Preview Newsletter 2", language: "ENGLISH", cardType: .book),
+                    Card(id: 1170, title: "Preview Title 3", topKeyword: "Preview Keyword 3", summary: "Preview Summary 3", contentURL: "https://example.com", imageURL: nil, newsletterName: "Preview Newsletter 3", language: "ENGLISH", cardType: .newsletter),
+                    Card(id: 1123, title: "Preview Title 4", topKeyword: "Preview Keyword 4", summary: "Preview Summary 4", contentURL: "https://example.com", imageURL: nil, newsletterName: "Preview Newsletter 4", language: "ENGLISH", cardType: .unknown),
+                    Card(id: 1148, title: "Preview Title 5", topKeyword: "Preview Keyword 5", summary: "Preview Summary 5", contentURL: "https://example.com", imageURL: nil, newsletterName: "Preview Newsletter 5", language: "ENGLISH", cardType: .userProvideContent),
+                    Card(id: 938, title: "Preview Title 6", topKeyword: "Preview Keyword 6", summary: "Preview Summary 6", contentURL: "https://example.com", imageURL: nil, newsletterName: "Preview Newsletter 6", language: "ENGLISH", cardType: .blog)
                 ]
             },
             fetchExploreCards: { _ in

--- a/NewsLetter/NewsLetter/Source/Data/Client/CardClient.swift
+++ b/NewsLetter/NewsLetter/Source/Data/Client/CardClient.swift
@@ -41,6 +41,7 @@ extension CardClient: DependencyKey {
                             topKeyword: cardDTO.topKeyword,
                             summary: cardDTO.summary,
                             contentURL: cardDTO.contentURL,
+                            imageURL: cardDTO.imageURL,
                             newsletterName: cardDTO.newsletterName,
                             language: cardDTO.language
                         )
@@ -67,12 +68,12 @@ extension CardClient: DependencyKey {
         return CardClient(
             fetchCards: { _ in
                 return [
-                    Card(id: 1192, title: "Preview Title 1", topKeyword: "Preview Keyword 1", summary: "Preview Summary 1", contentURL: "https://example.com", newsletterName: "Preview Newsletter 1", language: "ENGLISH"),
-                    Card(id: 1201, title: "Preview Title 2", topKeyword: "Preview Keyword 2", summary: "Preview Summary 2", contentURL: "https://example.com", newsletterName: "Preview Newsletter 2", language: "ENGLISH"),
-                    Card(id: 1170, title: "Preview Title 3", topKeyword: "Preview Keyword 3", summary: "Preview Summary 3", contentURL: "https://example.com", newsletterName: "Preview Newsletter 3", language: "ENGLISH"),
-                    Card(id: 1123, title: "Preview Title 4", topKeyword: "Preview Keyword 4", summary: "Preview Summary 4", contentURL: "https://example.com", newsletterName: "Preview Newsletter 4", language: "ENGLISH"),
-                    Card(id: 1148, title: "Preview Title 5", topKeyword: "Preview Keyword 5", summary: "Preview Summary 5", contentURL: "https://example.com", newsletterName: "Preview Newsletter 5", language: "ENGLISH"),
-                    Card(id: 938, title: "Preview Title 6", topKeyword: "Preview Keyword 6", summary: "Preview Summary 6", contentURL: "https://example.com", newsletterName: "Preview Newsletter 6", language: "ENGLISH")
+                    Card(id: 1192, title: "Preview Title 1", topKeyword: "Preview Keyword 1", summary: "Preview Summary 1", contentURL: "https://example.com", imageURL: nil, newsletterName: "Preview Newsletter 1", language: "ENGLISH"),
+                    Card(id: 1201, title: "Preview Title 2", topKeyword: "Preview Keyword 2", summary: "Preview Summary 2", contentURL: "https://example.com", imageURL: nil, newsletterName: "Preview Newsletter 2", language: "ENGLISH"),
+                    Card(id: 1170, title: "Preview Title 3", topKeyword: "Preview Keyword 3", summary: "Preview Summary 3", contentURL: "https://example.com", imageURL: nil, newsletterName: "Preview Newsletter 3", language: "ENGLISH"),
+                    Card(id: 1123, title: "Preview Title 4", topKeyword: "Preview Keyword 4", summary: "Preview Summary 4", contentURL: "https://example.com", imageURL: nil, newsletterName: "Preview Newsletter 4", language: "ENGLISH"),
+                    Card(id: 1148, title: "Preview Title 5", topKeyword: "Preview Keyword 5", summary: "Preview Summary 5", contentURL: "https://example.com", imageURL: nil, newsletterName: "Preview Newsletter 5", language: "ENGLISH"),
+                    Card(id: 938, title: "Preview Title 6", topKeyword: "Preview Keyword 6", summary: "Preview Summary 6", contentURL: "https://example.com", imageURL: nil, newsletterName: "Preview Newsletter 6", language: "ENGLISH")
                 ]
             },
             fetchExploreCards: { _ in

--- a/NewsLetter/NewsLetter/Source/Data/Client/CardClient.swift
+++ b/NewsLetter/NewsLetter/Source/Data/Client/CardClient.swift
@@ -55,12 +55,12 @@ extension CardClient: DependencyKey {
         return CardClient(
             fetchCards: { _ in
                 return [
-                    Card(id: 1192, title: "Preview Title 1", topKeyword: "Preview Keyword 1", summary: "Preview Summary 1", contentURL: "https://example.com", imageURL: nil, newsletterName: "Preview Newsletter 1", language: "ENGLISH", cardType: .blog),
-                    Card(id: 1201, title: "Preview Title 2", topKeyword: "Preview Keyword 2", summary: "Preview Summary 2", contentURL: "https://example.com", imageURL: nil, newsletterName: "Preview Newsletter 2", language: "ENGLISH", cardType: .book),
-                    Card(id: 1170, title: "Preview Title 3", topKeyword: "Preview Keyword 3", summary: "Preview Summary 3", contentURL: "https://example.com", imageURL: nil, newsletterName: "Preview Newsletter 3", language: "ENGLISH", cardType: .newsletter),
-                    Card(id: 1123, title: "Preview Title 4", topKeyword: "Preview Keyword 4", summary: "Preview Summary 4", contentURL: "https://example.com", imageURL: nil, newsletterName: "Preview Newsletter 4", language: "ENGLISH", cardType: .unknown),
-                    Card(id: 1148, title: "Preview Title 5", topKeyword: "Preview Keyword 5", summary: "Preview Summary 5", contentURL: "https://example.com", imageURL: nil, newsletterName: "Preview Newsletter 5", language: "ENGLISH", cardType: .userProvideContent),
-                    Card(id: 938, title: "Preview Title 6", topKeyword: "Preview Keyword 6", summary: "Preview Summary 6", contentURL: "https://example.com", imageURL: nil, newsletterName: "Preview Newsletter 6", language: "ENGLISH", cardType: .blog)
+                    Card(id: 1192, title: "Preview Title 1", topKeyword: "Preview Keyword 1", summary: "Preview Summary 1", contentURL: "https://example.com", imageURL: nil, newsletterName: "Preview Newsletter 1", language: "ENGLISH", kind: .blog),
+                    Card(id: 1201, title: "Preview Title 2", topKeyword: "Preview Keyword 2", summary: "Preview Summary 2", contentURL: "https://example.com", imageURL: nil, newsletterName: "Preview Newsletter 2", language: "ENGLISH", kind: .book),
+                    Card(id: 1170, title: "Preview Title 3", topKeyword: "Preview Keyword 3", summary: "Preview Summary 3", contentURL: "https://example.com", imageURL: nil, newsletterName: "Preview Newsletter 3", language: "ENGLISH", kind: .book),
+                    Card(id: 1123, title: "Preview Title 4", topKeyword: "Preview Keyword 4", summary: "Preview Summary 4", contentURL: "https://example.com", imageURL: nil, newsletterName: "Preview Newsletter 4", language: "ENGLISH", kind: .book),
+                    Card(id: 1148, title: "Preview Title 5", topKeyword: "Preview Keyword 5", summary: "Preview Summary 5", contentURL: "https://example.com", imageURL: nil, newsletterName: "Preview Newsletter 5", language: "ENGLISH", kind: .book),
+                    Card(id: 938, title: "Preview Title 6", topKeyword: "Preview Keyword 6", summary: "Preview Summary 6", contentURL: "https://example.com", imageURL: nil, newsletterName: "Preview Newsletter 6", language: "ENGLISH", kind: .blog)
                 ]
             },
             fetchExploreCards: { _ in

--- a/NewsLetter/NewsLetter/Source/Data/DTO/CardResponseDTO.swift
+++ b/NewsLetter/NewsLetter/Source/Data/DTO/CardResponseDTO.swift
@@ -18,6 +18,7 @@ struct CardDTO: Decodable {
     let id: Int
     let title, topKeyword, summary: String
     let contentURL: String
+    let imageURL: String?
     let newsletterName: String
     let language: String
 
@@ -25,6 +26,7 @@ struct CardDTO: Decodable {
         case id
         case title, topKeyword, summary
         case contentURL = "contentUrl"
+        case imageURL = "imageUrl"
         case newsletterName
         case language
     }

--- a/NewsLetter/NewsLetter/Source/Data/DTO/CardResponseDTO.swift
+++ b/NewsLetter/NewsLetter/Source/Data/DTO/CardResponseDTO.swift
@@ -10,13 +10,14 @@ import Foundation
 // MARK: - CardClient
 struct CardResponseDTO: Decodable {
     let publishedDate: String
-    let trendingCard: CardDTO
+    let trendingCard: CardDTO?
     let cards: [CardDTO]
     
     func toDomain() -> [Card] {
-        let trendingCard = trendingCard.toDomain()
         var cardList = cards.map { $0.toDomain() }
-        cardList.insert(trendingCard, at: 0)
+        if let trendingCard = trendingCard?.toDomain() {
+            cardList.insert(trendingCard, at: 0)
+        }
         return cardList
     }
 }

--- a/NewsLetter/NewsLetter/Source/Data/DTO/CardResponseDTO.swift
+++ b/NewsLetter/NewsLetter/Source/Data/DTO/CardResponseDTO.swift
@@ -51,7 +51,7 @@ struct CardDTO: Decodable {
             imageURL: imageURL,
             newsletterName: newsletterName,
             language: language,
-            cardType: cardType
+            kind: cardType.toDomain()
         )
     }
 }
@@ -68,7 +68,7 @@ enum CardType: String, Codable {
         self = CardType(rawValue: raw) ?? .unknown
     }
     
-    func toDomain() -> RecommendCardCellProps.Kind {
+    func toDomain() -> Card.Kind {
         switch self {
         case .blog:               return .blog
         case .book:               return .book

--- a/NewsLetter/NewsLetter/Source/Data/DTO/CardResponseDTO.swift
+++ b/NewsLetter/NewsLetter/Source/Data/DTO/CardResponseDTO.swift
@@ -10,7 +10,15 @@ import Foundation
 // MARK: - CardClient
 struct CardResponseDTO: Decodable {
     let publishedDate: String
+    let trendingCard: CardDTO
     let cards: [CardDTO]
+    
+    func toDomain() -> [Card] {
+        let trendingCard = trendingCard.toDomain()
+        var cardList = cards.map { $0.toDomain() }
+        cardList.insert(trendingCard, at: 0)
+        return cardList
+    }
 }
 
 // MARK: - Card
@@ -21,6 +29,7 @@ struct CardDTO: Decodable {
     let imageURL: String?
     let newsletterName: String
     let language: String
+    let cardType: CardType
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -29,6 +38,44 @@ struct CardDTO: Decodable {
         case imageURL = "imageUrl"
         case newsletterName
         case language
+        case cardType
+    }
+    
+    func toDomain() -> Card {
+        return Card(
+            id: id,
+            title: title,
+            topKeyword: topKeyword,
+            summary: summary,
+            contentURL: contentURL,
+            imageURL: imageURL,
+            newsletterName: newsletterName,
+            language: language,
+            cardType: cardType
+        )
+    }
+}
+
+enum CardType: String, Codable {
+    case blog = "BLOG"
+    case newsletter = "NEWSLETTER"
+    case userProvideContent = "USER_PROVIDE_CONTENT"
+    case unknown = "UNKNOWN"
+    case book = "BOOK"
+
+    init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self = CardType(rawValue: raw) ?? .unknown
+    }
+    
+    func toDomain() -> RecommendCardCellProps.Kind {
+        switch self {
+        case .blog:               return .blog
+        case .book:               return .book
+        case .newsletter:         return .news
+        case .userProvideContent: return .blog // FIXME: 기획 추가 필요
+        case .unknown:            return .blog // FIXME: 기획 추가 필요
+        }
     }
 }
 

--- a/NewsLetter/NewsLetter/Source/Data/UserInfo.swift
+++ b/NewsLetter/NewsLetter/Source/Data/UserInfo.swift
@@ -20,10 +20,6 @@ struct UserInfo {
     @UserDefaultWrapper(key: "cachedExploreCards", defaultValue: nil)
     static var cachedExploreCards: [ExploreCard]?
 
-    /// 매핑된 카드 컬러 정보
-    @UserDefaultWrapper(key: "cachedDailyColors", defaultValue: nil)
-    static var cachedDailyColors: [ColorPaletteName]?
-
     /// 유저가 마지막 API를 호출한 날짜
     @UserDefaultWrapper(key: "lastCardFetchDate", defaultValue: nil)
     static var lastCardFetchDate: Date?

--- a/NewsLetter/NewsLetter/Source/DesignSystem/CachedAsyncImage.swift
+++ b/NewsLetter/NewsLetter/Source/DesignSystem/CachedAsyncImage.swift
@@ -1,0 +1,69 @@
+//
+//  CachedAsyncImage.swift
+//  NewsLetter
+//
+
+import SwiftUI
+
+private final class ImageCache {
+    static let shared = ImageCache()
+    private var cache = NSCache<NSString, UIImage>()
+
+    private init() {
+        cache.countLimit = 100
+        cache.totalCostLimit = 50 * 1024 * 1024 // 50MB
+    }
+
+    func get(_ url: String) -> UIImage? {
+        cache.object(forKey: url as NSString)
+    }
+
+    func set(_ image: UIImage, for url: String) {
+        cache.setObject(image, forKey: url as NSString, cost: image.jpegData(compressionQuality: 1)?.count ?? 0)
+    }
+}
+
+struct CachedAsyncImage<Placeholder: View>: View {
+    private let url: String
+    private let placeholder: Placeholder
+
+    @State private var image: UIImage?
+    @State private var isLoading = false
+
+    init(url: String, @ViewBuilder placeholder: () -> Placeholder) {
+        self.url = url
+        self.placeholder = placeholder()
+    }
+
+    var body: some View {
+        Group {
+            if let image {
+                Image(uiImage: image)
+                    .resizable()
+            } else {
+                placeholder
+                    .onAppear { load() }
+            }
+        }
+    }
+
+    private func load() {
+        if let cached = ImageCache.shared.get(url) {
+            image = cached
+            return
+        }
+        guard !isLoading, let requestURL = URL(string: url) else { return }
+        isLoading = true
+
+        Task {
+            do {
+                let (data, _) = try await URLSession.shared.data(from: requestURL)
+                if let loaded = UIImage(data: data) {
+                    ImageCache.shared.set(loaded, for: url)
+                    await MainActor.run { image = loaded }
+                }
+            } catch {}
+            await MainActor.run { isLoading = false }
+        }
+    }
+}

--- a/NewsLetter/NewsLetter/Source/DesignSystem/Color/ColorPalette.swift
+++ b/NewsLetter/NewsLetter/Source/DesignSystem/Color/ColorPalette.swift
@@ -122,6 +122,18 @@ enum ColorPalette {
     static let pointLemonYellow800 = Color(hex: 0x728808)
     static let pointLemonYellow900 = Color(hex: 0x586908)
     
+    static let pointMint50 = Color(hex: 0xF2FFFD)
+    static let pointMint100 = Color(hex: 0xE8FFFC)
+    static let pointMint150 = Color(hex: 0xD3FCF6)
+    static let pointMint200 = Color(hex: 0xBDF8F0)
+    static let pointMint300 = Color(hex: 0x7AF0E5)
+    static let pointMint400 = Color(hex: 0x33E9D6)
+    static let pointMint500 = Color(hex: 0x00E7CE)
+    static let pointMint600 = Color(hex: 0x00C7B0)
+    static let pointMint700 = Color(hex: 0x009C8C)
+    static let pointMint800 = Color(hex: 0x00887A)
+    static let pointMint900 = Color(hex: 0x006E63)
+                                        
     // Text Primary
     static let pointBlueTextPrimary = Color(hex: 0x68A4E7)
     static let pointOrangeTextPrimary = Color(hex: 0xF38338)
@@ -129,4 +141,5 @@ enum ColorPalette {
     static let pointPurpleTextPrimary = Color(hex: 0xA888C7)
     static let pointGreenTextPrimary = Color(hex: 0x41D17F)
     static let pointLemonYellowTextPrimary = Color(hex: 0xCBE064)
+    static let pointMintTextPrimary = Color(hex: 0x04AD9B)
 }

--- a/NewsLetter/NewsLetter/Source/DesignSystem/Color/ColorPalette.swift
+++ b/NewsLetter/NewsLetter/Source/DesignSystem/Color/ColorPalette.swift
@@ -121,4 +121,12 @@ enum ColorPalette {
     static let pointLemonYellow700 = Color(hex: 0x8CA70B)
     static let pointLemonYellow800 = Color(hex: 0x728808)
     static let pointLemonYellow900 = Color(hex: 0x586908)
+    
+    // Text Primary
+    static let pointBlueTextPrimary = Color(hex: 0x68A4E7)
+    static let pointOrangeTextPrimary = Color(hex: 0xF38338)
+    static let pointPinkTextPrimary = Color(hex: 0xFC98DB)
+    static let pointPurpleTextPrimary = Color(hex: 0xA888C7)
+    static let pointGreenTextPrimary = Color(hex: 0x41D17F)
+    static let pointLemonYellowTextPrimary = Color(hex: 0xCBE064)
 }

--- a/NewsLetter/NewsLetter/Source/DesignSystem/Constants.swift
+++ b/NewsLetter/NewsLetter/Source/DesignSystem/Constants.swift
@@ -18,11 +18,11 @@ enum Z {
 
 typealias COLORSET = (main: Color, sub: Color)
 let COLORSET_LIST: [COLORSET] = [
-    (ColorPalette.gray400, ColorPalette.gray100), // FIXME: TrandingCard 색상지정 필요
-    (ColorPalette.pointPurple200, ColorPalette.pointPurpleTextPrimary),
-    (ColorPalette.pointOrange400, ColorPalette.pointOrangeTextPrimary),
     (ColorPalette.pointBlue300, ColorPalette.pointBlueTextPrimary),
     (ColorPalette.pointLemonYellow300, ColorPalette.pointLemonYellowTextPrimary),
+    (ColorPalette.pointPurple200, ColorPalette.pointPurpleTextPrimary),
+    (ColorPalette.pointMint500, ColorPalette.pointMintTextPrimary),
     (ColorPalette.pointPink300, ColorPalette.pointPinkTextPrimary),
     (ColorPalette.pointGreen300, ColorPalette.pointGreenTextPrimary),
+    (ColorPalette.pointOrange400, ColorPalette.pointOrangeTextPrimary),
 ]

--- a/NewsLetter/NewsLetter/Source/DesignSystem/Constants.swift
+++ b/NewsLetter/NewsLetter/Source/DesignSystem/Constants.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftUI
 
 /// ZIndex 상수 정의
 enum Z {
@@ -14,3 +15,13 @@ enum Z {
     static let carouselModal: Double = 20
     static let bottomSheet: Double = 50
 }
+
+typealias COLORSET = (main: Color, sub: Color)
+let COLORSET_LIST: [COLORSET] = [
+    (ColorPalette.pointPurple200, ColorPalette.pointPurpleTextPrimary),
+    (ColorPalette.pointOrange400, ColorPalette.pointOrangeTextPrimary),
+    (ColorPalette.pointBlue300, ColorPalette.pointBlueTextPrimary),
+    (ColorPalette.pointLemonYellow300, ColorPalette.pointLemonYellowTextPrimary),
+    (ColorPalette.pointPink300, ColorPalette.pointPinkTextPrimary),
+    (ColorPalette.pointGreen300, ColorPalette.pointGreenTextPrimary),
+]

--- a/NewsLetter/NewsLetter/Source/DesignSystem/Constants.swift
+++ b/NewsLetter/NewsLetter/Source/DesignSystem/Constants.swift
@@ -18,6 +18,7 @@ enum Z {
 
 typealias COLORSET = (main: Color, sub: Color)
 let COLORSET_LIST: [COLORSET] = [
+    (ColorPalette.gray400, ColorPalette.gray100), // FIXME: TrandingCard 색상지정 필요
     (ColorPalette.pointPurple200, ColorPalette.pointPurpleTextPrimary),
     (ColorPalette.pointOrange400, ColorPalette.pointOrangeTextPrimary),
     (ColorPalette.pointBlue300, ColorPalette.pointBlueTextPrimary),

--- a/NewsLetter/NewsLetter/Source/DesignSystem/Constants.swift
+++ b/NewsLetter/NewsLetter/Source/DesignSystem/Constants.swift
@@ -16,8 +16,9 @@ enum Z {
     static let bottomSheet: Double = 50
 }
 
-typealias COLORSET = (main: Color, sub: Color)
-let COLORSET_LIST: [COLORSET] = [
+typealias ColorSet = (main: Color, sub: Color)
+
+let defaultColorSet: [ColorSet] = [
     (ColorPalette.pointBlue300, ColorPalette.pointBlueTextPrimary),
     (ColorPalette.pointLemonYellow300, ColorPalette.pointLemonYellowTextPrimary),
     (ColorPalette.pointPurple200, ColorPalette.pointPurpleTextPrimary),
@@ -26,3 +27,10 @@ let COLORSET_LIST: [COLORSET] = [
     (ColorPalette.pointGreen300, ColorPalette.pointGreenTextPrimary),
     (ColorPalette.pointOrange400, ColorPalette.pointOrangeTextPrimary),
 ]
+
+extension [Card] {
+    var colorSet: [ColorSet] {
+        let dropCount = Swift.max(defaultColorSet.count - self.count, 0)
+        return defaultColorSet.suffix(from: dropCount).map { $0 }
+    }
+}

--- a/NewsLetter/NewsLetter/Source/Domain/Entity/Card.swift
+++ b/NewsLetter/NewsLetter/Source/Domain/Entity/Card.swift
@@ -14,7 +14,13 @@ struct Card: Codable {
     let imageURL: String?
     let newsletterName: String
     let language: String
-    let cardType: CardType
+    let kind: Kind
+    
+    enum Kind: String, Codable {
+        case news
+        case blog
+        case book
+    }
 
     var displayLanguage: String {
         switch language.uppercased() {
@@ -34,7 +40,7 @@ struct Card: Codable {
         imageURL: String = "https://picsum.photos/400/300",
         newsletterName: String = "안드로이드 위클리",
         language: String = "ENGLISH",
-        cardType: CardType = .newsletter
+        kind: Kind = .news
     ) -> Self {
         return .init(
             id: id,
@@ -45,7 +51,7 @@ struct Card: Codable {
             imageURL: imageURL,
             newsletterName: newsletterName,
             language: language,
-            cardType: cardType
+            kind: kind
         )
     }
 }

--- a/NewsLetter/NewsLetter/Source/Domain/Entity/Card.swift
+++ b/NewsLetter/NewsLetter/Source/Domain/Entity/Card.swift
@@ -11,6 +11,7 @@ struct Card: Codable {
     let topKeyword: String
     let summary: String
     let contentURL: String
+    let imageURL: String?
     let newsletterName: String
     let language: String
 
@@ -29,6 +30,7 @@ struct Card: Codable {
         topKeyword: String = "Kotlin",
         summary: String = "Anatolii Frolov는 Kotlin 객체 싱글톤이 Gson과 같은 라이브러리에 의해 복제될 수 있으므로 역직렬화할 때 실제 싱글톤 동작을 유지하려면 사용자 정의 어댑터가 필요하다고 강조합니다.Anatolii Frolov는 Kotlin 객체 싱글톤이 Gson과 같은 라이브러리에 의해 복제될 수 있으므로 역렬화할 때 실제 싱글톤 동작을 강조합니다.",
         contentURL: String = "https://substack.com/redirect/3966a1cb-5964-4e4c-a46c-67fd93586b71?j=eyJ1IjoiNjBoYXcyIn0.sgwjhuRgLj2i1p7EiKYAd1HGVttvTH1zz-7ivhBT090",
+        imageURL: String = "https://picsum.photos/400/300",
         newsletterName: String = "안드로이드 위클리",
         language: String = "ENGLISH"
     ) -> Self {
@@ -38,6 +40,7 @@ struct Card: Codable {
             topKeyword: topKeyword,
             summary: summary,
             contentURL: contentURL,
+            imageURL: imageURL,
             newsletterName: newsletterName,
             language: language
         )

--- a/NewsLetter/NewsLetter/Source/Domain/Entity/Card.swift
+++ b/NewsLetter/NewsLetter/Source/Domain/Entity/Card.swift
@@ -14,6 +14,7 @@ struct Card: Codable {
     let imageURL: String?
     let newsletterName: String
     let language: String
+    let cardType: CardType
 
     var displayLanguage: String {
         switch language.uppercased() {
@@ -32,7 +33,8 @@ struct Card: Codable {
         contentURL: String = "https://substack.com/redirect/3966a1cb-5964-4e4c-a46c-67fd93586b71?j=eyJ1IjoiNjBoYXcyIn0.sgwjhuRgLj2i1p7EiKYAd1HGVttvTH1zz-7ivhBT090",
         imageURL: String = "https://picsum.photos/400/300",
         newsletterName: String = "안드로이드 위클리",
-        language: String = "ENGLISH"
+        language: String = "ENGLISH",
+        cardType: CardType = .newsletter
     ) -> Self {
         return .init(
             id: id,
@@ -42,7 +44,8 @@ struct Card: Codable {
             contentURL: contentURL,
             imageURL: imageURL,
             newsletterName: newsletterName,
-            language: language
+            language: language,
+            cardType: cardType
         )
     }
 }

--- a/NewsLetter/NewsLetter/Source/Domain/Entity/ExploreCard.swift
+++ b/NewsLetter/NewsLetter/Source/Domain/Entity/ExploreCard.swift
@@ -41,6 +41,7 @@ struct ExploreCard: Codable {
             topKeyword: topKeyword,
             summary: summary,
             contentURL: contentURL,
+            imageURL: nil,
             newsletterName: newsletterName,
             language: language
         )

--- a/NewsLetter/NewsLetter/Source/Domain/Entity/ExploreCard.swift
+++ b/NewsLetter/NewsLetter/Source/Domain/Entity/ExploreCard.swift
@@ -44,7 +44,7 @@ struct ExploreCard: Codable {
             imageURL: nil,
             newsletterName: newsletterName,
             language: language,
-            cardType: .unknown // FIXME: 탐색카드에서 CardType 기획 필요
+            kind: .blog // FIXME: 탐색카드에서 CardType 기획 필요
         )
     }
 }

--- a/NewsLetter/NewsLetter/Source/Domain/Entity/ExploreCard.swift
+++ b/NewsLetter/NewsLetter/Source/Domain/Entity/ExploreCard.swift
@@ -43,7 +43,8 @@ struct ExploreCard: Codable {
             contentURL: contentURL,
             imageURL: nil,
             newsletterName: newsletterName,
-            language: language
+            language: language,
+            cardType: .unknown // FIXME: 탐색카드에서 CardType 기획 필요
         )
     }
 }


### PR DESCRIPTION
## 📌 Summary
  추천탭 카드 UI를 리뉴얼하고, 무한 순환 캐로셀 및 이미지 캐시 컴포넌트를 추가합니다.

  ## ✍️ Description
  - close: #107

  - 추천탭 카드셀 UI 전면 리뉴얼 (`RecommendCardCell`)
  - 무한 순환 캐로셀 구현: `[D, A, B, C, D, A]` 클론 구조 + `.viewAligned` 스냅
  - 양옆 카드 scale / blur / rotation3D 효과 적용
  - 페이지 인디케이터 추가 (현재 카드 하이라이트)
  - 이미지 URL 기반 캐시 이미지 컴포넌트 추가 (`CachedAsyncImage`)
  - `SingleModalView` 추가 및 적용
  - `imageURL` 응답 필드 추가 (`CardResponseDTO`, `Card` 엔티티)
  - 컬러셋 상수 추가 (`COLORSET_LIST`)

  ## 💡 PR Point
  - 무한 순환 스크롤: `.viewAligned` + `isJumping` 플래그로 클론 위치 점프 시 애니메이션만 선택적으로 비활성화
    (`.transaction { t in if isJumping { t.disablesAnimations = true } }`)
  - `contentMargins`를 사용해 `.padding`이 아닌 ScrollView 마진 처리 → `.viewAligned` 스냅 기준 정확도 유지
  - `CachedAsyncImage`: `NSCache` 기반 메모리 캐시 (최대 100장 / 50MB), `@ViewBuilder` placeholder로 외부 주입

  ## 📚 Reference
<img width="200" alt="IMG_9002" src="https://github.com/user-attachments/assets/d4b6b8b7-1a5c-4ccd-9b0e-992eff6f9d75" />

  ## 🔥 Test
  - [ ] 추천탭 카드 캐로셀 정방향/역방향 무한 스크롤 동작 확인
  - [ ] 양옆 카드 scale / blur / 회전 효과 확인
  - [ ] 페이지 인디케이터 동기화 확인
 