### PR TITLE
[#114] refactor: 컴포넌트 변경에 따른 GA 로그 재연결

### DIFF
--- a/NewsLetter/NewsLetter/Source/Application/Feature/Explore/Component/ExploreCardModalView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Explore/Component/ExploreCardModalView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 import ComposableArchitecture
-import FirebaseAnalytics
 
 struct ExploreCardModalView: View {
     private enum Metric {

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Explore/Component/NewsletterReportBottomSheet.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Explore/Component/NewsletterReportBottomSheet.swift
@@ -96,6 +96,12 @@ struct NewsletterReportBottomSheet: View {
                 let categoryNames = categories.indices
                     .filter { selectedCategories.contains($0) }
                     .map { categories[$0].label }
+                GA.explore_report_click(
+                    name: newsletterURL,
+                    url: blogURL,
+                    jobGroup: categoryNames.joined(separator: ","),
+                    language: memo
+                )
                 let dto = NewsletterReportRequestDTO(
                     contentProviderName: newsletterURL,
                     channel: blogURL,
@@ -120,6 +126,9 @@ struct NewsletterReportBottomSheet: View {
             .padding(.bottom, 8)
         }
         .padding(.top, 4)
+        .onAppear {
+            GA.explore_report_pageview()
+        }
     }
 
     @ViewBuilder

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Explore/ExploreView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Explore/ExploreView.swift
@@ -49,9 +49,15 @@ struct ExploreView: View {
                             )
                             .frame(height: Metrics.cardHeight)
                             .onTapGesture {
-                                let selectedCard = (data.toCard(), colorPallete)
-                                store.send(.setSelectedCard(selectedCard))
-                                
+                                let card = data.toCard()
+                                GA.explore_contents_detail_pageview(
+                                    cardIndex: index,
+                                    contentType: card.kind.gaContentType,
+                                    contentTitle: card.title,
+                                    contentId: card.id
+                                )
+                                store.send(.setSelectedCard((card, colorPallete)))
+
                                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                                     store.send(.delegate(.presentExploreCard))
                                 }
@@ -81,6 +87,7 @@ struct ExploreView: View {
             .ignoresSafeArea()
             .background(Color.black)
             .onAppear {
+                GA.explore_pageview()
                 UIScrollView.appearance().indicatorStyle = .white
                 UIRefreshControl.appearance().tintColor = .white
                 store.send(.onAppear)

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/Component/CarouselModalView/CarouselCard.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/Component/CarouselModalView/CarouselCard.swift
@@ -8,8 +8,6 @@
 import SwiftUI
 import WebKit
 
-import FirebaseAnalytics
-
 struct CarouselCard: View {
     private enum Metric {
         static let height: CGFloat = 366
@@ -27,6 +25,7 @@ struct CarouselCard: View {
     let index: Int
     let pointColor: Color
     let isShareEnabled: Bool
+    var cardType: String = "recommend"
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -96,10 +95,18 @@ struct CarouselCard: View {
                 Button {
                     isWebViewPresented = true
                     if isShareEnabled {
-                        /// 여긴 CarouselModalView 영역
-                        GA.click_newsletter_carousel(title: card.title, listIndex: index)
+                        GA.main_contents_detail_click(
+                            cardType: cardType,
+                            contentType: card.kind.gaContentType,
+                            contentTitle: card.title,
+                            contentId: card.id
+                        )
                     } else {
-                        /// 여긴 ExploreCardModalView 영역
+                        GA.explore_contents_detail_click(
+                            contentType: card.kind.gaContentType,
+                            contentTitle: card.title,
+                            contentId: card.id
+                        )
                     }
                 } label: {
                     RoundedRectangle(cornerRadius: Metric.nextButtonCornerRadius)

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/Component/CarouselModalView/CarouselModalView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/Component/CarouselModalView/CarouselModalView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 import ComposableArchitecture
-import FirebaseAnalytics
 
 struct CarouselModalView: View {
     private enum Metric {
@@ -19,8 +18,6 @@ struct CarouselModalView: View {
         static let indicatorSize: CGFloat = 8
         static let xButtonSize: CGFloat = 44
     }
-
-    @State private var loggedImpressionIndices: Set<Int> = []
 
     @State var cardData: [Card]
     @State var pointColors: [Color]
@@ -46,7 +43,8 @@ struct CarouselModalView: View {
                         ForEach(cardData.indices, id: \.self) { index in
                             let card = cardData[index]
                             let pointColor = pointColors[index]
-                            CarouselCard(card: card, index: index, pointColor: pointColor, isShareEnabled: true)
+                            let cardType = index == cardData.count - 1 ? "trending" : "recommend"
+                    CarouselCard(card: card, index: index, pointColor: pointColor, isShareEnabled: true, cardType: cardType)
                                 .frame(width: Metric.cardWidth)
                         }
                     }
@@ -66,19 +64,6 @@ struct CarouselModalView: View {
                         }
                     }
                 ))
-                .onChange(of: currentPage) { _, newPage in
-                    guard let newIndex = newPage else { return }
-
-                    if !loggedImpressionIndices.contains(newIndex) {
-                        let actualIndex = cardData.count - 1 - newIndex
-
-                        let card = cardData[actualIndex]
-                        GA.impression_newsletter_carousel(title: card.title, listIndex: actualIndex)
-
-                        loggedImpressionIndices.insert(actualIndex)
-                    }
-                }
-
                 HStack(spacing: Metric.indicatorSize) {
                     ForEach(0..<cardData.count, id: \.self) { index in
                         Circle()
@@ -104,15 +89,18 @@ struct CarouselModalView: View {
                 .padding(.top, 43)
             }
         }
-        .onAppear() {
-            if let initialIndex = currentPage, !loggedImpressionIndices.contains(initialIndex) {
-                let actualIndex = cardData.count-1-initialIndex
+        .onAppear {
+            if let initialIndex = currentPage {
+                let actualIndex = cardData.count - 1 - initialIndex
                 let card = cardData[actualIndex]
-
-                GA.pageview_newsletter_carousel(title: card.title)
-                GA.impression_newsletter_carousel(title: card.title, listIndex: actualIndex)
-
-                loggedImpressionIndices.insert(actualIndex)
+                let cardType = initialIndex == 0 ? "trending" : "recommend"
+                GA.main_contents_detail_pageview(
+                    cardIndex: initialIndex,
+                    cardType: cardType,
+                    contentType: card.kind.gaContentType,
+                    contentTitle: card.title,
+                    contentId: card.id
+                )
             }
         }
     }

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/Component/CarouselModalView/SingleModalView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/Component/CarouselModalView/SingleModalView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 import ComposableArchitecture
-import FirebaseAnalytics
 
 struct SingleModalView: View {
     private enum Metric {
@@ -31,12 +30,18 @@ struct SingleModalView: View {
                 .onTapGesture {
                     isPresented = false
                 }
-            
+
             VStack(spacing: 0) {
-                
-                CarouselCard(card: cardData, index: index, pointColor: pointColor, isShareEnabled: true)
-                    .frame(width: Metric.cardWidth, height: Metric.cardHeight)
-                
+
+                CarouselCard(
+                    card: cardData,
+                    index: index,
+                    pointColor: pointColor,
+                    isShareEnabled: true,
+                    cardType: index == 0 ? "trending" : "recommend"
+                )
+                .frame(width: Metric.cardWidth, height: Metric.cardHeight)
+
                 Button {
                     if UserActionHistory.isFirstLook == false {
                         UserActionHistory.isFirstLook = true
@@ -51,6 +56,15 @@ struct SingleModalView: View {
                 }
                 .padding(.top, 43)
             }
+        }
+        .onAppear {
+            GA.main_contents_detail_pageview(
+                cardIndex: index,
+                cardType: index == 0 ? "trending" : "recommend",
+                contentType: cardData.kind.gaContentType,
+                contentTitle: cardData.title,
+                contentId: cardData.id
+            )
         }
     }
 }

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/RecommendView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/RecommendView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 import ComposableArchitecture
-import FirebaseAnalytics
 
 struct RecommendView: View {
     private enum Metric {
@@ -47,8 +46,8 @@ struct RecommendView: View {
         .animation(.smooth, value: scrolledID)
         .transition(.opacity)
         .onAppear {
-            GA.pageview_main()
-            
+            GA.main_pageview()
+
             store.send(.onAppear)
             
             if UserActionHistory.isFirstAppLaunch {
@@ -131,7 +130,6 @@ struct RecommendView: View {
                                 scrolledID = index
                                 return
                             }
-                            GA.click_newsletter(title: data.title, listIndex: index)
                             selectedIndex = index
                             cardTapHandler()
                         }

--- a/NewsLetter/NewsLetter/Source/Utils/AnalyticsManager.swift
+++ b/NewsLetter/NewsLetter/Source/Utils/AnalyticsManager.swift
@@ -11,97 +11,187 @@ import FirebaseAnalytics
 
 enum GA {
 
-    // MARK: - Newsletter Main
-
-    static func pageview_main() {
-        Analytics.logEvent("pageview_main", parameters: [
-            "category": "pageview",
-            "navigation": "main"
-        ])
+    private static var isPreview: Bool {
+        ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
     }
 
-    static func click_newsletter(title: String, listIndex: Int) {
-        let dataString = ["list_index": listIndex].toJSONString()
-        Analytics.logEvent("click_newsletter", parameters: [
-            "category": "click",
+    // MARK: - Main
+
+    static func main_pageview() {
+        guard !isPreview else { return }
+        Analytics.logEvent("main_pageview", parameters: [
             "navigation": "main",
-            "object_section": "newsletter_list",
-            "object_type": "newsletter",
-            "object_id": title,
-            "data": dataString ?? ""
+            "event": "pageview"
         ])
     }
 
-    // MARK: - Newsletter Carousel
-
-    static func pageview_newsletter_carousel(title: String) {
-        Analytics.logEvent("pageview_newsletter_carousel", parameters: [
-            "category": "pageview",
-            "navigation": "newsletter_carousel",
-            "object_type": "newsletter",
-            "object_id": title
+    static func main_contents_detail_pageview(
+        cardIndex: Int,
+        cardType: String,
+        contentType: String,
+        contentTitle: String,
+        contentId: Int
+    ) {
+        guard !isPreview else { return }
+        Analytics.logEvent("main_contents_detail_pageview", parameters: [
+            "navigation": "main_contents_detail",
+            "event": "pageview",
+            "card_index": cardIndex,
+            "card_type": cardType,
+            "content_type": contentType,
+            "content_title": contentTitle,
+            "content_id": contentId
         ])
     }
 
-    static func impression_newsletter_carousel(title: String, listIndex: Int) {
-        let dataString = ["list_index": listIndex].toJSONString()
-        Analytics.logEvent("impression_newsletter_carousel", parameters: [
-            "category": "impression",
-            "navigation": "newsletter_carousel",
-            "object_section": "newsletter_card",
-            "object_type": "newsletter",
-            "object_id": title,
-            "data": dataString ?? ""
+    static func main_contents_detail_click(
+        cardType: String,
+        contentType: String,
+        contentTitle: String,
+        contentId: Int
+    ) {
+        guard !isPreview else { return }
+        Analytics.logEvent("main_contents_detail_click", parameters: [
+            "navigation": "main_contents_detail",
+            "event": "click",
+            "card_type": cardType,
+            "content_type": contentType,
+            "content_title": contentTitle,
+            "content_id": contentId
         ])
     }
 
-    static func click_newsletter_carousel(title: String, listIndex: Int) {
-        let dataString = ["list_index": listIndex].toJSONString()
-        Analytics.logEvent("click_newsletter_carousel", parameters: [
-            "category": "click",
-            "navigation": "newsletter_carousel",
-            "object_section": "newsletter_card",
-            "object_type": "button",
-            "object_id": title,
-            "data": dataString ?? ""
+    // MARK: - Explore
+
+    static func explore_pageview() {
+        guard !isPreview else { return }
+        Analytics.logEvent("explore_pageview", parameters: [
+            "navigation": "explore",
+            "event": "pageview"
+        ])
+    }
+
+    static func explore_contents_detail_pageview(
+        cardIndex: Int,
+        contentType: String,
+        contentTitle: String,
+        contentId: Int
+    ) {
+        guard !isPreview else { return }
+        Analytics.logEvent("explore_contents_detail_pageview", parameters: [
+            "navigation": "explore_contents_detail",
+            "event": "pageview",
+            "card_index": cardIndex,
+            "content_type": contentType,
+            "content_title": contentTitle,
+            "content_id": contentId
+        ])
+    }
+
+    static func explore_contents_detail_click(
+        contentType: String,
+        contentTitle: String,
+        contentId: Int
+    ) {
+        guard !isPreview else { return }
+        Analytics.logEvent("explore_contents_detail_click", parameters: [
+            "navigation": "explore_contents_detail",
+            "event": "click",
+            "content_type": contentType,
+            "content_title": contentTitle,
+            "content_id": contentId
+        ])
+    }
+
+    static func explore_click_order(orderBy: String) {
+        guard !isPreview else { return }
+        Analytics.logEvent("explore_click", parameters: [
+            "navigation": "explore",
+            "event": "click",
+            "action_type": "order",
+            "order_by": orderBy
+        ])
+    }
+
+    static func explore_click_filter(filterValue: String) {
+        guard !isPreview else { return }
+        Analytics.logEvent("explore_click", parameters: [
+            "navigation": "explore",
+            "event": "click",
+            "action_type": "filter",
+            "filter_value": filterValue
+        ])
+    }
+
+    static func explore_report_pageview() {
+        guard !isPreview else { return }
+        Analytics.logEvent("explore_report_pageview", parameters: [
+            "navigation": "explore_report",
+            "event": "pageview"
+        ])
+    }
+
+    static func explore_report_click(
+        name: String,
+        url: String,
+        jobGroup: String,
+        language: String
+    ) {
+        guard !isPreview else { return }
+        Analytics.logEvent("explore_report_click", parameters: [
+            "navigation": "explore_report",
+            "event": "click",
+            "action_type": "submit_report_form",
+            "name": name,
+            "url": url,
+            "job_group": jobGroup,
+            "language": language
         ])
     }
 
     // MARK: - Bottom Sheet
 
     static func pageview_bottom_sheet_notification() {
-        Analytics.logEvent("pageview_bottom_sheet_notification", parameters: [
-            "category": "pageview",
+        guard !isPreview else { return }
+        Analytics.logEvent("bottom_sheet_notification_pageview", parameters: [
             "navigation": "bottom_sheet_notification",
-            "object_type": "bottom_sheet"
+            "event": "pageview"
         ])
     }
 
     static func click_bottom_sheet_notification() {
-        Analytics.logEvent("click_bottom_sheet_notification", parameters: [
-            "category": "click",
+        guard !isPreview else { return }
+        Analytics.logEvent("bottom_sheet_notification_click", parameters: [
             "navigation": "bottom_sheet_notification",
-            "object_type": "button"
+            "event": "click"
         ])
     }
 
     static func pageview_bottom_sheet_custom() {
-        Analytics.logEvent("pageview_bottom_sheet_custom", parameters: [
-            "category": "pageview",
+        guard !isPreview else { return }
+        Analytics.logEvent("bottom_sheet_custom_pageview", parameters: [
             "navigation": "bottom_sheet_custom",
-            "object_type": "bottom_sheet"
+            "event": "pageview"
         ])
     }
 
     static func click_bottom_sheet_custom(userData: [String: Any]) {
+        guard !isPreview else { return }
         let dataString = userData.toJSONString()
-        Analytics.logEvent("click_bottom_sheet_custom", parameters: [
-            "category": "click",
+        Analytics.logEvent("bottom_sheet_custom_click", parameters: [
             "navigation": "bottom_sheet_custom",
-            "object_section": "bottom_sheet",
-            "object_type": "button",
+            "event": "click",
             "user_properties": dataString ?? ""
         ])
     }
 }
 
+extension Card.Kind {
+    var gaContentType: String {
+        switch self {
+        case .news: return "newsletter"
+        case .blog: return "blog"
+        case .book: return "book"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- 로그 명세서 기준으로 GA 이벤트 전면 재정의 및 재연결
- Preview 환경에서 GA 이벤트가 수집되지 않도록 가드 추가
- `SingleModalView` 누락된 pageview 이벤트 추가 및 `cardType` 오류 수정

## 변경 상세

### AnalyticsManager.swift
- 기존 이벤트 제거: `pageview_main`, `click_newsletter`, `pageview_newsletter_carousel`, `impression_newsletter_carousel`, `click_newsletter_carousel`
- 신규 이벤트 추가 (명세서 기준):
  - 메인: `main_pageview`, `main_contents_detail_pageview`, `main_contents_detail_click`
  - 탐색: `explore_pageview`, `explore_contents_detail_pageview`, `explore_contents_detail_click`, `explore_click_order`, `explore_click_filter`, `explore_report_pageview`, `explore_report_click`
  - 바텀시트: 기존 4개 유지 (event_name만 명세서 기준으로 정렬)
- `guard !isPreview else { return }` 추가 → Preview 환경에서 Firebase 미발송
- `Card.Kind.gaContentType` extension 추가 (`news` → `"newsletter"` 등 매핑)

### 이벤트 연결 위치

| 이벤트 | 위치 |
|---|---|
| `main_pageview` | `RecommendView.onAppear` |
| `main_contents_detail_pageview` | `SingleModalView.onAppear` |
| `main_contents_detail_click` | `CarouselCard` — 원문 보기 버튼 (`isShareEnabled = true`) |
| `explore_pageview` | `ExploreView.onAppear` |
| `explore_contents_detail_pageview` | `ExploreView` — 카드 탭 시 |
| `explore_contents_detail_click` | `CarouselCard` — 원문 보기 버튼 (`isShareEnabled = false`) |
| `explore_report_pageview` | `NewsletterReportBottomSheet.onAppear` |
| `explore_report_click` | `NewsletterReportBottomSheet` — 제출 버튼 |

### 버그 수정
- `SingleModalView`에 `main_contents_detail_pageview` 누락 수정 (CarouselModalView에 연결했으나 실제 앱은 SingleModalView 사용)
- `SingleModalView → CarouselCard` 전달 시 `cardType`이 항상 `"recommend"`로 고정되던 문제 수정 (`index == 0 ? "trending" : "recommend"`)

## Test plan

- [ ] 메인탭 진입 시 `main_pageview` 수집 확인
- [ ] 카드 탭 → 모달 진입 시 `main_contents_detail_pageview` 수집 확인 (`card_index`, `card_type`, `content_type`, `content_title`, `content_id` 포함)
- [ ] 첫 번째 카드 모달에서 `card_type = "trending"`, 나머지는 `"recommend"` 확인
- [ ] 원문 보기 클릭 시 `main_contents_detail_click` 수집 확인
- [ ] 탐색탭 진입 시 `explore_pageview` 수집 확인
- [ ] 탐색탭 카드 탭 시 `explore_contents_detail_pageview` 수집 확인
- [ ] 탐색탭 원문 보기 클릭 시 `explore_contents_detail_click` 수집 확인
- [ ] 뉴스레터 제보 바텀시트 진입 시 `explore_report_pageview` 수집 확인
- [ ] 제출 버튼 탭 시 `explore_report_click` 수집 확인 (`name`, `url`, `job_group`, `language` 포함)
- [ ] Xcode Preview 실행 시 Firebase 이벤트 미발송 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)