### PR TITLE
[#119] chore: OG 이미지 생성 URL 수정

### DIFF
--- a/.claude/skills/pr.md
+++ b/.claude/skills/pr.md
@@ -83,7 +83,7 @@ git diff {베이스브랜치}...HEAD
 
 **✍️ Description**
 - 구현 방식, 구조 변경, 주요 파일을 bullet point로 서술합니다.
-- `- close: #이슈번호`를 첫 줄에 포함합니다. 이슈 번호가 없으면 `- close: ` 빈칸으로 둡니다.
+- `closes #이슈번호`를 첫 줄에 포함합니다. 이슈 번호가 없으면 `closes #` 빈칸으로 둡니다.
 - TCA 패턴 변경(Reducer, Action, State, Delegate Action)이 있으면 언급합니다.
 
 **💡 PR Point**
@@ -119,7 +119,7 @@ git diff {베이스브랜치}...HEAD
 
 ## ✍️ Description
 <!-- PR에 대한 자세한 설명을 써주세요. -->
-- close: #{이슈번호}
+closes #{이슈번호}
 {설명 bullet points}
 
 ## 💡 PR Point

--- a/NewsLetter/NewsLetter/Source/Data/Client/CardClient.swift
+++ b/NewsLetter/NewsLetter/Source/Data/Client/CardClient.swift
@@ -47,7 +47,7 @@ extension CardClient: DependencyKey {
                 },
                 fetchOGShareURL: { requestDTO in
                     let textColorEncoded = requestDTO.textColor?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
-                    let urlString = "https://fairy-band.com/api/share/og?exposureContentId=\(requestDTO.exposureContentId)&textColor=\(textColorEncoded)"
+                    let urlString = "\(AppInfo.baseURL)/share/og?exposureContentId=\(requestDTO.exposureContentId)&textColor=\(textColorEncoded)"
                     return urlString
                 }
             )
@@ -79,7 +79,7 @@ extension CardClient: DependencyKey {
                 ]
             },
             fetchOGShareURL: { _ in
-                return "https://fairy-band.com/api/share/og?exposureContentId=2&textColor=%23DCFF64"
+                return "\(AppInfo.baseURL)/share/og?exposureContentId=2&textColor=%23DCFF64"
             }
         )
     }()


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
카카오 공유 OG 이미지 URL의 잘못된 경로와 하드코딩을 수정합니다.


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
closes #119
- `CardClient.fetchOGShareURL`에서 `https://fairy-band.com/api/share/og`로 하드코딩되어 있던 URL을 `AppInfo.baseURL` 기반으로 변경
- 실제 서버 엔드포인트는 `/share/og`인데 `/api` prefix가 포함되어 있어 404 응답이 반환되던 문제 수정
- `liveValue`, `previewValue` 두 곳 모두 수정

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
- 다른 API들은 `baseURL + /api/...` 구조이지만 `/share/og`는 `/api` prefix가 없는 예외 경로입니다. `CardAPI.swift`의 `path`도 `/share/og`로 되어 있으니 혼동 주의

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->
<!-- 참고한 디자인 시안, 피그마 링크 등이 있다면 직접 추가해주세요 -->


## 🔥 Test
<!-- Test -->
- [ ] 카카오 공유 버튼 탭 후 카카오톡 공유 메시지에 OG 이미지 썸네일 정상 노출 확인
- [ ] 공유 후 카카오톡 채팅방에서 미리보기 이미지가 올바른 카드 내용으로 표시되는지 확인