### PR TITLE
[#126] feat: 직군 선택 상태 반영

### DIFF
--- a/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/Component/JobDetailBottomSheet/JobDetailBottomSheet.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/Component/JobDetailBottomSheet/JobDetailBottomSheet.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import FirebaseAnalytics
 
 struct JobDetailBottomSheet: View {
-    @State private var selectedJobCategory: Set<Int> = []
+    @State private var selectedJobCategory: Set<Int>
     @State private var selectedCareer: Int?
 
     private var isEnabledButton: Bool {
@@ -18,6 +18,16 @@ struct JobDetailBottomSheet: View {
     }
 
     let confirmHandler: (Set<Int>, Int) -> Void
+
+    init(
+        initialSelectedJobCategory: Set<Int> = [],
+        initialSelectedCareer: Int? = nil,
+        confirmHandler: @escaping (Set<Int>, Int) -> Void
+    ) {
+        _selectedJobCategory = State(initialValue: initialSelectedJobCategory)
+        _selectedCareer = State(initialValue: initialSelectedCareer)
+        self.confirmHandler = confirmHandler
+    }
 
     var body: some View {
         VStack(spacing: 0) {

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Setting/SettingReducer.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Setting/SettingReducer.swift
@@ -23,6 +23,8 @@ struct SettingReducer {
     struct State {
         var path = StackState<Path.State>()
         var isPresentJobDetailBottomSheet = false
+        var selectedPreferences: [Preference] = []
+        var selectedWorkingExperience: WorkingExperience?
         var isPresentNotificationPermissionBottomSheet = false
         var isPresentToastMessage = false
         var isPresentNotiToastMessage = false
@@ -40,6 +42,8 @@ struct SettingReducer {
         case onAppear
         case onDisappear
         case updateUser(UserUpdateRequestDTO)
+        case jobDetailSettingTapped
+        case fetchUserInfoResponse(UserResponseDTO)
         case setIsPresentJobDetailBottomSheet(Bool)
         case setIsPresentNotificationPermissionBottomSheet(Bool)
         case setIsPresentToastMessage(Bool)
@@ -76,6 +80,22 @@ struct SettingReducer {
                         print(error.localizedDescription)
                     }
                 }
+            case .jobDetailSettingTapped:
+                return .run { send in
+                    do {
+                        guard let userId = UserInfo.userId else { return }
+                        let response = try await userClient.fetchUser(userId)
+                        await send(.fetchUserInfoResponse(response))
+                    } catch {
+                        // TODO: 에러 핸들링
+                        print(error.localizedDescription)
+                    }
+                }
+            case .fetchUserInfoResponse(let response):
+                state.selectedPreferences = response.preferences
+                state.selectedWorkingExperience = response.workingExperience
+                state.isPresentJobDetailBottomSheet = true
+                return .none
             case .setIsPresentJobDetailBottomSheet(let bool):
                 state.isPresentJobDetailBottomSheet = bool
                 return .none

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Setting/SettingView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Setting/SettingView.swift
@@ -19,7 +19,7 @@ struct SettingView: View {
             
             VStack(alignment: .leading, spacing: 24) {
                 sectionTitle(title: "내정보")
-                navigationRow(title: "맞춤 설정") { store.send(.setIsPresentJobDetailBottomSheet(true)) }
+                navigationRow(title: "맞춤 설정") { store.send(.jobDetailSettingTapped) }
                 navigationRow(title: "알림") { store.send(.setIsPresentNotificationPermissionBottomSheet(true)) }
                 
                 Divider()
@@ -50,7 +50,10 @@ struct SettingView: View {
             isShow: $store.isPresentJobDetailBottomSheet,
             dismissHandler: { UserActionHistory.deniedDateWhenInputJobDetail = Date() }
         ) {
-            JobDetailBottomSheet { selectedJobCategory, selectedCareer in
+            JobDetailBottomSheet(
+                initialSelectedJobCategory: Set(store.selectedPreferences.compactMap { Preference.allCases.firstIndex(of: $0) }),
+                initialSelectedCareer: store.selectedWorkingExperience.flatMap { WorkingExperience.allCases.firstIndex(of: $0) }
+            ) { selectedJobCategory, selectedCareer in
                 jobDetailBottomSheetConfirmHandler(
                     selectedJobCategory: selectedJobCategory,
                     selectedCareer: selectedCareer

--- a/NewsLetter/NewsLetter/Source/Data/API/UserAPI.swift
+++ b/NewsLetter/NewsLetter/Source/Data/API/UserAPI.swift
@@ -13,6 +13,7 @@ enum UserAPI {
     case login(UserLoginRequestDTO)
     case register(UserRegisterRequestDTO)
     case update(userId: Int, requestDTO: UserUpdateRequestDTO)
+    case fetchUser(userId: Int)
 }
 
 extension UserAPI: TargetType {
@@ -26,20 +27,22 @@ extension UserAPI: TargetType {
     
     var path: String {
         switch self {
-        case .login:                 return "/users/login"
-        case .register:              return "/users/register"
-        case .update(let userId, _): return "/users/\(userId)"
+        case .login:                  return "/users/login"
+        case .register:               return "/users/register"
+        case .update(let userId, _):  return "/users/\(userId)"
+        case .fetchUser(let userId):  return "/users/\(userId)"
         }
     }
-    
+
     var method: Moya.Method {
         switch self {
-        case .login:    return .get
-        case .register: return .post
-        case .update:   return .put
+        case .login:      return .get
+        case .register:   return .post
+        case .update:     return .put
+        case .fetchUser:  return .get
         }
     }
-    
+
     var task: Task {
         switch self {
         case .login(let dto):
@@ -66,6 +69,8 @@ extension UserAPI: TargetType {
                 parameters: parameters,
                 encoding: JSONEncoding.default
             )
+        case .fetchUser:
+            return .requestPlain
         }
     }
 }

--- a/NewsLetter/NewsLetter/Source/Data/Client/UserClient.swift
+++ b/NewsLetter/NewsLetter/Source/Data/Client/UserClient.swift
@@ -17,6 +17,7 @@ struct UserClient {
     var login: (UserLoginRequestDTO) async throws -> Int
     var register: (UserRegisterRequestDTO) async throws -> Int
     var update: (Int, UserUpdateRequestDTO) async throws -> Void
+    var fetchUser: (Int) async throws -> UserResponseDTO
 }
 
 extension DependencyValues {
@@ -41,15 +42,22 @@ extension UserClient: DependencyKey {
         },
         update: { userId, requestDTO in
             let _ = try await apiClient.request(UserAPI.update(userId: userId, requestDTO: requestDTO))
+        },
+        fetchUser: { userId in
+            let response = try await apiClient.request(UserAPI.fetchUser(userId: userId))
+            return try response.map(UserResponseDTO.self)
         }
        )
     }()
-    
+
     static var previewValue: UserClient = {
         return UserClient(
             login: { _ in return 0 },
             register: { _ in return 0 },
-            update: { _, _ in return }
+            update: { _, _ in return },
+            fetchUser: { _ in
+                UserResponseDTO(id: 0, preferences: [.frontend], workingExperience: .student)
+            }
         )
     }()
     

--- a/NewsLetter/NewsLetter/Source/Data/DTO/UserResponseDTO.swift
+++ b/NewsLetter/NewsLetter/Source/Data/DTO/UserResponseDTO.swift
@@ -1,0 +1,12 @@
+//
+//  UserResponseDTO.swift
+//  NewsLetter
+//
+
+import Foundation
+
+struct UserResponseDTO: Decodable {
+    let id: Int
+    let preferences: [Preference]
+    let workingExperience: WorkingExperience
+}


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
설정 화면의 맞춤 설정 진입 시, 서버에 저장된 사용자의 직군/경력 정보를 조회해 이미 선택된 상태로 보여줍니다.


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
closes #126
- `UserAPI`에 `GET /users/{userId}` 조회용 `fetchUser` 케이스 추가
- `UserClient`에 `fetchUser` 의존성 추가 (live/preview/test 모두 구현)
- `UserResponseDTO` 신규 추가 (`id`, `preferences`, `workingExperience`)
- `SettingReducer`: "맞춤 설정" 탭 시 `jobDetailSettingTapped` → 유저 정보 조회 후 `isPresentJobDetailBottomSheet` 오픈
- `JobDetailBottomSheet`가 초기 선택값(`initialSelectedJobCategory`, `initialSelectedCareer`)을 받을 수 있도록 이니셜라이저 추가

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
- `JobDetailBottomSheet` 이니셜라이저 변경은 파라미터 기본값을 유지해 기존 호출부(HomeView)는 수정 없이 그대로 동작합니다.
- 유저 정보 조회 실패 시 별도 에러 UI 없이 print만 하고 있어, 필요 시 에러 핸들링 보완이 필요합니다.

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->


## 🔥 Test
<!-- Test -->
- [ ] 맞춤 설정 진입 시 서버에 저장된 직군/경력이 미리 체크되어 보이는지 확인
- [ ] 신규 사용자(등록 정보 없음)의 경우 바텀시트가 빈 선택 상태로 정상 노출되는지 확인
- [ ] 선택 변경 후 저장이 정상 동작하는지 확인
- [ ] API 호출 실패 시 앱 크래시 없이 동작하는지 확인