### PR TITLE
[#131] feat: 온보딩 후 직군 변경 바텀시트 노출

### DIFF
--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeReducer.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeReducer.swift
@@ -26,9 +26,10 @@ struct HomeReducer {
         var isPresentModal: Bool = false
         var isPresentExploreCard: Bool = false
         var isPresentNotificationPermissionBottomSheet: Bool = false
-        var isPresentJobDetailBottomSheet: Bool = false
+        var isPresentOnboardingJobBottomSheet: Bool = false
         var isPresentNewsletterReportBottomSheet: Bool = false
         var isPresentToastMessage: Bool = false
+        var isPresentJobChangeToastMessage: Bool = false
         var isPresentReportSuccessToast: Bool = false
         var selectedIndex: Int?
     }
@@ -70,8 +71,8 @@ struct HomeReducer {
             case .recommend(.delegate(.presentNotificationPermissionBottomSheet)):
                 state.isPresentNotificationPermissionBottomSheet = true
                 return .none
-            case .recommend(.delegate(.presentJobDetailBottomSheet)):
-                state.isPresentJobDetailBottomSheet = true
+            case .recommend(.delegate(.presentOnboardingJobBottomSheet)):
+                state.isPresentOnboardingJobBottomSheet = true
                 return .none
             // ExploreReducer의 delegate 액션 처리
             case .explore(.delegate(.presentExploreCard)):
@@ -83,6 +84,10 @@ struct HomeReducer {
             case .settingPressed:
                 state.path.append(.setting(SettingReducer.State()))
                 return .none
+            // 설정 화면에서 직군/경력 정보가 갱신되면 추천 컨텐츠를 새로 불러옵니다.
+            case .path(.element(id: _, action: .setting(.delegate(.categoryUpdated)))):
+                state.recommendState.isCardLoading = true
+                return .send(.recommend(.fetchCards))
             case .submitNewsletterReport(let dto):
                 return .run { send in
                     do {

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
@@ -113,12 +113,15 @@ struct HomeView: View {
             )
             .reportSuccessToast(
                 isPresented: $store.isPresentReportSuccessToast,
-                topPadding: (UIDevice.isSmallScreen ? 24 : 50) + (UIDevice.isSmallScreen ? 36 : 48) + 8
+                padding: (UIDevice.isSmallScreen ? 24 : 50) + (UIDevice.isSmallScreen ? 36 : 48) + 8
             )
-            .toastMessage(
+            .reportSuccessToast(
                 isPresented: $store.isPresentJobChangeToastMessage,
                 text: "변경이 완료되었어요",
-                bottomPadding: 0
+                edge: .bottom,
+                padding: 75,
+                backgroundColor: Color(hex: 0x3F4247),
+                textColor: .white
             )
             .confirmAlertDialog(
                 isPresented: $isPresentJobChangeConfirmAlert,

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Home/HomeView.swift
@@ -12,7 +12,10 @@ import ComposableArchitecture
 
 struct HomeView: View {
     @Bindable var store: StoreOf<HomeReducer>
-    
+
+    @State private var isPresentJobChangeConfirmAlert = false
+    @State private var pendingJobChangeCommit: (() -> Void)?
+
     var body: some View {
         NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
             VStack(spacing: 0) {
@@ -62,11 +65,16 @@ struct HomeView: View {
                 }
             }
             .draggableBottomSheet(
-                isShow: $store.isPresentJobDetailBottomSheet,
-                dismissHandler: { UserActionHistory.deniedDateWhenInputJobDetail = Date() }
+                isShow: $store.isPresentOnboardingJobBottomSheet,
+                dismissHandler: {
+                    store.send(.recommend(.onboardingJobDetailConfirmed(preferences: nil, workingExperience: nil)))
+                }
             ) {
-                JobDetailBottomSheet { selectedJobCategory, selectedCareer in
-                    jobDetailBottomSheetConfirmHandler(
+                JobDetailBottomSheet(
+                    isCategoryChanged: store.recommendState.isCategoryChanged,
+                    requestChangeConfirmation: requestJobChangeConfirmation
+                ) { selectedJobCategory, selectedCareer in
+                    onboardingJobDetailBottomSheetConfirmHandler(
                         selectedJobCategory: selectedJobCategory,
                         selectedCareer: selectedCareer
                     )
@@ -107,6 +115,20 @@ struct HomeView: View {
                 isPresented: $store.isPresentReportSuccessToast,
                 topPadding: (UIDevice.isSmallScreen ? 24 : 50) + (UIDevice.isSmallScreen ? 36 : 48) + 8
             )
+            .toastMessage(
+                isPresented: $store.isPresentJobChangeToastMessage,
+                text: "변경이 완료되었어요",
+                bottomPadding: 0
+            )
+            .confirmAlertDialog(
+                isPresented: $isPresentJobChangeConfirmAlert,
+                message: JobDetailBottomSheet.changeConfirmationMessage,
+                confirmTitle: "변경하기",
+                confirmHandler: {
+                    pendingJobChangeCommit?()
+                    pendingJobChangeCommit = nil
+                }
+            )
             .animation(.easeInOut, value: store.isPresentModal)
             .animation(.easeInOut, value: store.isPresentExploreCard)
         } destination: { store in
@@ -117,19 +139,23 @@ struct HomeView: View {
         }
     }
     
-    private func jobDetailBottomSheetConfirmHandler(
+    private func requestJobChangeConfirmation(commit: @escaping () -> Void) {
+        pendingJobChangeCommit = commit
+        isPresentJobChangeConfirmAlert = true
+    }
+
+    private func onboardingJobDetailBottomSheetConfirmHandler(
         selectedJobCategory: Set<Int>,
         selectedCareer: Int
     ) {
         let preferences = selectedJobCategory.map { Preference.allCases[$0] }
         let workingExperience = WorkingExperience.allCases[selectedCareer]
-        let requestDTO = UserUpdateRequestDTO(
+        store.send(.recommend(.onboardingJobDetailConfirmed(
             preferences: preferences,
             workingExperience: workingExperience
-        )
-        store.send(.recommend(.updateUser(requestDTO)))
-        store.send(.recommend(.onAppear))
-        store.isPresentJobDetailBottomSheet = false
+        )))
+        store.isPresentOnboardingJobBottomSheet = false
+        store.isPresentJobChangeToastMessage = true
     }
 }
 

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/Component/JobDetailBottomSheet/JobDetailBottomSheet.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/Component/JobDetailBottomSheet/JobDetailBottomSheet.swift
@@ -10,22 +10,38 @@ import SwiftUI
 import FirebaseAnalytics
 
 struct JobDetailBottomSheet: View {
+    static let changeConfirmationMessage = "관심 직군 변경은 **계정당 한 번만 가능**합니다. 변경 후에는 다른 직군으로 수정할 수 없습니다."
+
     @State private var selectedJobCategory: Set<Int>
     @State private var selectedCareer: Int?
 
+    /// 서버에서 내려준, 계정당 1회 허용되는 직군 변경을 이미 사용했는지 여부. true면 이미 변경 이력이 있어 더 이상 변경할 수 없습니다.
+    let isCategoryChanged: Bool
+    /// 진입 시점에 이미 등록된 직군 정보가 있었는지 여부. 최초 등록(정보가 없던 상태)에서는 확인 다이얼로그 없이 바로 반영하고,
+    /// 기존 정보를 수정하는 경우에만 확인 다이얼로그를 거칩니다.
+    private let hasExistingSelection: Bool
+
     private var isEnabledButton: Bool {
-        selectedCareer != nil && selectedJobCategory.isEmpty == false
+        selectedCareer != nil && selectedJobCategory.isEmpty == false && isCategoryChanged == false
     }
 
     let confirmHandler: (Set<Int>, Int) -> Void
+    /// 바텀시트 영역에 갇히지 않고 화면 전체 기준으로 확인 다이얼로그를 띄울 수 있도록,
+    /// 다이얼로그 노출 자체는 상위 화면(호출부)에 위임합니다. 사용자가 다이얼로그에서 확정하면 전달받은 `commit`을 호출해주세요.
+    let requestChangeConfirmation: (_ commit: @escaping () -> Void) -> Void
 
     init(
         initialSelectedJobCategory: Set<Int> = [],
         initialSelectedCareer: Int? = nil,
+        isCategoryChanged: Bool = false,
+        requestChangeConfirmation: @escaping (_ commit: @escaping () -> Void) -> Void = { commit in commit() },
         confirmHandler: @escaping (Set<Int>, Int) -> Void
     ) {
         _selectedJobCategory = State(initialValue: initialSelectedJobCategory)
         _selectedCareer = State(initialValue: initialSelectedCareer)
+        self.isCategoryChanged = isCategoryChanged
+        self.hasExistingSelection = initialSelectedJobCategory.isEmpty == false || initialSelectedCareer != nil
+        self.requestChangeConfirmation = requestChangeConfirmation
         self.confirmHandler = confirmHandler
     }
 
@@ -35,6 +51,11 @@ struct JobDetailBottomSheet: View {
                 .font(.head22_bold)
                 .multilineTextAlignment(.center)
                 .padding(.top, 20)
+
+            Text("* 계정당 한 번의 직군 변경만 허용하고 있어요.")
+                .font(.body13_medium)
+                .foregroundStyle(.semanticColor.text_tertiary)
+                .padding(.top, 4)
                 .padding(.bottom, 12)
 
             VStack(alignment: .leading, spacing: 0) {
@@ -95,27 +116,11 @@ struct JobDetailBottomSheet: View {
             .padding(.bottom, 24)
 
             Button {
-                UserActionHistory.isAlreadyInputJobDetail = true
-                confirmHandler(selectedJobCategory, selectedCareer ?? 0)
-
-                let preferences = selectedJobCategory.map { Preference.allCases[$0].rawValue }
-
-                guard let selectedCareer = selectedCareer else {
-                    print("❌ 경력 정보가 선택되지 않았습니다.")
-                    return
+                if hasExistingSelection {
+                    requestChangeConfirmation { performConfirm() }
+                } else {
+                    performConfirm()
                 }
-                let workingExperience = WorkingExperience.allCases[selectedCareer].rawValue
-
-                if UserActionHistory.selectedCareer != [preferences, [workingExperience]] {
-                    UserActionHistory.isChangedCareer = true
-                    UserActionHistory.selectedCareer = [preferences, [workingExperience]]
-                }
-
-                let dataDictionary: [String: Any] = [
-                    "job_group": preferences,
-                    "career_level": workingExperience
-                ]
-                GA.click_bottom_sheet_custom(userData: dataDictionary)
             } label: {
                 RoundedRectangle(cornerRadius: 100)
                     .frame(height: 56)
@@ -133,6 +138,30 @@ struct JobDetailBottomSheet: View {
         .onAppear() {
             GA.pageview_bottom_sheet_custom()
         }
+    }
+
+    private func performConfirm() {
+        UserActionHistory.isAlreadyInputJobDetail = true
+        confirmHandler(selectedJobCategory, selectedCareer ?? 0)
+
+        let preferences = selectedJobCategory.map { Preference.allCases[$0].rawValue }
+
+        guard let selectedCareer = selectedCareer else {
+            print("❌ 경력 정보가 선택되지 않았습니다.")
+            return
+        }
+        let workingExperience = WorkingExperience.allCases[selectedCareer].rawValue
+
+        if UserActionHistory.selectedCareer != [preferences, [workingExperience]] {
+            UserActionHistory.isChangedCareer = true
+            UserActionHistory.selectedCareer = [preferences, [workingExperience]]
+        }
+
+        let dataDictionary: [String: Any] = [
+            "job_group": preferences,
+            "career_level": workingExperience
+        ]
+        GA.click_bottom_sheet_custom(userData: dataDictionary)
     }
 }
 

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/RecommendReducer.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/RecommendReducer.swift
@@ -32,6 +32,7 @@ struct RecommendReducer {
         var isRefreshLoading: Bool = false
         // 카드 최초 로딩 여부. true일 때만 스켈레톤을 노출합니다.
         var isCardLoading: Bool = false
+        var isCategoryChanged: Bool = false
     }
     
     enum Action: BindableAction {
@@ -43,7 +44,11 @@ struct RecommendReducer {
         case tick
         case startTimer
         case setColorPalette([ColorSet])
+        case resolveCardFetch
         case fetchCards
+        case fetchOnboardingStatus
+        case onboardingStatusResponse(Result<UserResponseDTO, Error>)
+        case onboardingJobDetailConfirmed(preferences: [Preference]?, workingExperience: WorkingExperience?)
         case loginUser
         case registerUser
         case updateUser(UserUpdateRequestDTO)
@@ -51,12 +56,12 @@ struct RecommendReducer {
         case delegate(Delegate)
         case setIsPresentModal(Bool)
         case setIsRefreshLoading(Bool)
-        
+
         @CasePathable
         enum Delegate {
             case presentModal(Bool)
             case presentNotificationPermissionBottomSheet(Bool)
-            case presentJobDetailBottomSheet(Bool)
+            case presentOnboardingJobBottomSheet(Bool)
         }
     }
     
@@ -75,21 +80,41 @@ struct RecommendReducer {
             case .binding(_):
                 return .none
             case .onAppear:
-                var effects: [Effect<Action>] = []
                 state.todayDate = DateCalculator.formattedDateStringForTitle()
-                
+                DateCalculator.checkAndIncrementVisitStreak()
+
+                let timerEffect = Effect<Action>.send(.startTimer)
+                let loginEffect = Effect<Action>.send(.loginUser)
+                let delayEffect = Effect<Action>.run { _ in
+                    try await clock.sleep(for: .seconds(0.5))
+                }
+
+                // 온보딩 둘째날(streakCount >= 2)이면서 아직 온보딩 플로우가 끝나지 않았다면
+                // 컨텐츠 조회보다 먼저 온보딩 상태(isOnboarded)를 확인합니다.
+                let cardEffect: Effect<Action>
+                if UserActionHistory.isOnboardingFlowFinished == false && UserActionHistory.streakCount >= 2 {
+                    cardEffect = .send(.fetchOnboardingStatus)
+                } else {
+                    cardEffect = .send(.resolveCardFetch)
+                }
+
+                return .concatenate(timerEffect, loginEffect, delayEffect, cardEffect)
+
+            case .resolveCardFetch:
                 let todayString = DateCalculator.formattedDateString()
                 let lastVisitString = UserInfo.lastCardFetchDate.map {
                     DateCalculator.formattedDateString(from: $0)
                 } ?? ""
-                
-                if todayString == lastVisitString ,
+
+                var effect: Effect<Action> = .none
+
+                if todayString == lastVisitString,
                    let cachedCards = UserInfo.cachedDailyCards,
                    !cachedCards.isEmpty {
 
                     if UserActionHistory.isChangedCareer == true {
                         state.isCardLoading = true
-                        effects.append(.send(.fetchCards))
+                        effect = .send(.fetchCards)
                         UserActionHistory.isChangedCareer = false
                     } else {
                         state.cardData = cachedCards
@@ -98,19 +123,53 @@ struct RecommendReducer {
 
                 } else {
                     state.isCardLoading = true
-                    effects.append(.send(.fetchCards))
+                    effect = .send(.fetchCards)
                 }
-                
+
                 UserInfo.lastCardFetchDate = Date()
-                
-                let timerEffect = Effect<Action>.send(.startTimer)
-                let loginEffect = Effect<Action>.send(.loginUser)
-                let delayEffect = Effect<Action>.run { _ in
-                    try await clock.sleep(for: .seconds(0.5))
+                return effect
+
+            case .fetchOnboardingStatus:
+                return .run { send in
+                    guard let userId = UserInfo.userId else {
+                        await send(.resolveCardFetch)
+                        return
+                    }
+                    do {
+                        let response = try await userClient.fetchUser(userId)
+                        await send(.onboardingStatusResponse(.success(response)))
+                    } catch {
+                        await send(.onboardingStatusResponse(.failure(error)))
+                    }
                 }
-                let restEffect = Effect<Action>.merge(effects)
-                return .concatenate(timerEffect, loginEffect, delayEffect, restEffect)
-                
+
+            case let .onboardingStatusResponse(.success(response)):
+                state.isCategoryChanged = response.isCategoryChanged
+                if response.isOnboarded {
+                    // 둘째날 + 온보딩 진행 중: 바텀시트를 먼저 노출하고, 컨텐츠 조회는 선택/미선택 이후로 미룹니다.
+                    return .send(.delegate(.presentOnboardingJobBottomSheet(true)))
+                } else {
+                    UserActionHistory.isOnboardingFlowFinished = true
+                    return .send(.resolveCardFetch)
+                }
+
+            case .onboardingStatusResponse(.failure):
+                // 온보딩 상태 확인에 실패하면 기존처럼 컨텐츠 조회로 진행합니다.
+                return .send(.resolveCardFetch)
+
+            case let .onboardingJobDetailConfirmed(preferences, workingExperience):
+                UserActionHistory.isOnboardingFlowFinished = true
+                state.isCardLoading = true
+
+                if let preferences, let workingExperience {
+                    // 선택 완료: 직군 정보를 갱신한 뒤 그 정보를 반영한 컨텐츠를 조회합니다.
+                    let dto = UserUpdateRequestDTO(preferences: preferences, workingExperience: workingExperience)
+                    return .concatenate(.send(.updateUser(dto)), .send(.fetchCards))
+                } else {
+                    // 미선택: 랜덤 컨텐츠 조회로 온보딩을 종료합니다.
+                    return .send(.fetchCards)
+                }
+
             case let .setColorPalette(colors):
                 state.cardColors = colors
                 return .none

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/RecommendView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Recommend/RecommendView.swift
@@ -23,7 +23,6 @@ struct RecommendView: View {
     
     @Binding var selectedIndex: Int?
     
-    @State private var cardTapCount: Int = 0
     @State private var scrolledID: Int?
     
     var showRefreshButton: Bool {
@@ -66,17 +65,7 @@ struct RecommendView: View {
             GA.main_pageview()
 
             store.send(.onAppear)
-            
-            if UserActionHistory.isFirstAppLaunch {
-                UserActionHistory.isFirstAppLaunch = false
-                
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                    store.send(.delegate(.presentJobDetailBottomSheet(true)))
-                }
-            }
-            
-            DateCalculator.checkAndIncrementVisitStreak()
-            
+
             guard UserActionHistory.streakCount >= 2 &&
                     UserActionHistory.isAlreadySetNotification == false &&
                     DateCalculator.isCanShowNotificationPermissionBottomSheet()
@@ -264,24 +253,10 @@ struct RecommendView: View {
     }
     
     private func cardTapHandler() {
-        if cardTapCount >= 3 {
-            guard UserActionHistory.isAlreadyInputJobDetail == false &&
-                    DateCalculator.isCanShowJobDetailBottomSheet()
-            else {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                    store.isPresentModal = true
-                    store.send(.delegate(.presentModal(true)))
-                }
-                return
-            }
-            store.send(.delegate(.presentJobDetailBottomSheet(true)))
-        } else {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                store.isPresentModal = true
-                store.send(.delegate(.presentModal(true)))
-            }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            store.isPresentModal = true
+            store.send(.delegate(.presentModal(true)))
         }
-        cardTapCount += 1
     }
     
     private func cardRotationDegree(for position: Int) -> Double {

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Setting/SettingReducer.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Setting/SettingReducer.swift
@@ -25,6 +25,7 @@ struct SettingReducer {
         var isPresentJobDetailBottomSheet = false
         var selectedPreferences: [Preference] = []
         var selectedWorkingExperience: WorkingExperience?
+        var isCategoryChanged: Bool = false
         var isPresentNotificationPermissionBottomSheet = false
         var isPresentToastMessage = false
         var isPresentNotiToastMessage = false
@@ -53,6 +54,12 @@ struct SettingReducer {
         case setNavigateToTermsOfService(Bool)
         case versionRowTapped
         case didReceiveInstallationToken(String?)
+        case delegate(Delegate)
+
+        @CasePathable
+        enum Delegate {
+            case categoryUpdated
+        }
     }
     
     @Dependency(\.userClient) var userClient
@@ -75,6 +82,7 @@ struct SettingReducer {
                     do {
                         guard let userId = UserInfo.userId else { return }
                         try await userClient.update(userId, dto)
+                        await send(.delegate(.categoryUpdated))
                     } catch {
                         // TODO: 에러 핸들링
                         print(error.localizedDescription)
@@ -83,17 +91,36 @@ struct SettingReducer {
             case .jobDetailSettingTapped:
                 return .run { send in
                     do {
-                        guard let userId = UserInfo.userId else { return }
+                        let userId: Int
+                        if let existingUserId = UserInfo.userId {
+                            userId = existingUserId
+                        } else {
+                            // 아직 로그인/등록이 끝나지 않은 상태(홈 진입 직후 등)라면 여기서 먼저 확보합니다.
+                            guard let deviceToken = KeychainManager.shared.retrieveString(forKey: "deviceToken") else {
+                                print("[SettingReducer] deviceToken이 없어 맞춤 설정을 열 수 없습니다.")
+                                return
+                            }
+                            let fetchedUserId: Int
+                            do {
+                                fetchedUserId = try await userClient.login(UserLoginRequestDTO(deviceToken: deviceToken))
+                            } catch {
+                                fetchedUserId = try await userClient.register(UserRegisterRequestDTO(deviceToken: deviceToken))
+                            }
+                            UserInfo.userId = fetchedUserId
+                            userId = fetchedUserId
+                        }
+
                         let response = try await userClient.fetchUser(userId)
                         await send(.fetchUserInfoResponse(response))
                     } catch {
                         // TODO: 에러 핸들링
-                        print(error.localizedDescription)
+                        print("[SettingReducer] 맞춤 설정 조회 실패: \(error.localizedDescription)")
                     }
                 }
             case .fetchUserInfoResponse(let response):
                 state.selectedPreferences = response.preferences
                 state.selectedWorkingExperience = response.workingExperience
+                state.isCategoryChanged = response.isCategoryChanged
                 state.isPresentJobDetailBottomSheet = true
                 return .none
             case .setIsPresentJobDetailBottomSheet(let bool):
@@ -143,6 +170,8 @@ struct SettingReducer {
                     state.isTokenCopyable = false
                 }
                 state.isPresentTokenToast = true
+                return .none
+            case .delegate:
                 return .none
             }
         }

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Setting/SettingReducer.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Setting/SettingReducer.swift
@@ -78,11 +78,15 @@ struct SettingReducer {
             case .onDisappear:
                 return .none
             case .updateUser(let dto):
+                // 경력만 바뀌고 관심 직군(preferences)이 그대로면 추천 컨텐츠에 영향이 없으므로 홈 새로고침을 생략합니다.
+                let didPreferencesChange = Set(dto.preferences.map(\.rawValue)) != Set(state.selectedPreferences.map(\.rawValue))
                 return .run { send in
                     do {
                         guard let userId = UserInfo.userId else { return }
                         try await userClient.update(userId, dto)
-                        await send(.delegate(.categoryUpdated))
+                        if didPreferencesChange {
+                            await send(.delegate(.categoryUpdated))
+                        }
                     } catch {
                         // TODO: 에러 핸들링
                         print(error.localizedDescription)

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Setting/SettingView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Setting/SettingView.swift
@@ -11,7 +11,10 @@ import ComposableArchitecture
 
 struct SettingView: View {
     @Bindable var store: StoreOf<SettingReducer>
-    
+
+    @State private var isPresentJobChangeConfirmAlert = false
+    @State private var pendingJobChangeCommit: (() -> Void)?
+
     var body: some View {
         VStack(spacing: 0) {
             CustomNavigationBar()
@@ -48,11 +51,13 @@ struct SettingView: View {
         }
         .draggableBottomSheet(
             isShow: $store.isPresentJobDetailBottomSheet,
-            dismissHandler: { UserActionHistory.deniedDateWhenInputJobDetail = Date() }
+            dismissHandler: {}
         ) {
             JobDetailBottomSheet(
                 initialSelectedJobCategory: Set(store.selectedPreferences.compactMap { Preference.allCases.firstIndex(of: $0) }),
-                initialSelectedCareer: store.selectedWorkingExperience.flatMap { WorkingExperience.allCases.firstIndex(of: $0) }
+                initialSelectedCareer: store.selectedWorkingExperience.flatMap { WorkingExperience.allCases.firstIndex(of: $0) },
+                isCategoryChanged: store.isCategoryChanged,
+                requestChangeConfirmation: requestJobChangeConfirmation
             ) { selectedJobCategory, selectedCareer in
                 jobDetailBottomSheetConfirmHandler(
                     selectedJobCategory: selectedJobCategory,
@@ -64,7 +69,7 @@ struct SettingView: View {
         .ignoresSafeArea(edges: .bottom)
         .toastMessage(
             isPresented: $store.isPresentToastMessage,
-            text: "직군정보 등록이 완료되었어요.",
+            text: "변경이 완료되었어요",
             bottomPadding: 0
         )
         .draggableBottomSheet(
@@ -101,8 +106,22 @@ struct SettingView: View {
         .navigationDestination(isPresented: $store.navigateToTermsOfService) {
             TermsOfServiceView()
         }
+        .confirmAlertDialog(
+            isPresented: $isPresentJobChangeConfirmAlert,
+            message: JobDetailBottomSheet.changeConfirmationMessage,
+            confirmTitle: "변경하기",
+            confirmHandler: {
+                pendingJobChangeCommit?()
+                pendingJobChangeCommit = nil
+            }
+        )
     }
-    
+
+    private func requestJobChangeConfirmation(commit: @escaping () -> Void) {
+        pendingJobChangeCommit = commit
+        isPresentJobChangeConfirmAlert = true
+    }
+
     private func jobDetailBottomSheetConfirmHandler(
         selectedJobCategory: Set<Int>,
         selectedCareer: Int
@@ -115,6 +134,7 @@ struct SettingView: View {
         )
         store.send(.updateUser(requestDTO))
         store.send(.setIsPresentJobDetailBottomSheet(false))
+        store.isPresentToastMessage = true
     }
     
     @ViewBuilder

--- a/NewsLetter/NewsLetter/Source/Application/Feature/Setting/SettingView.swift
+++ b/NewsLetter/NewsLetter/Source/Application/Feature/Setting/SettingView.swift
@@ -67,10 +67,13 @@ struct SettingView: View {
             }
         }
         .ignoresSafeArea(edges: .bottom)
-        .toastMessage(
+        .reportSuccessToast(
             isPresented: $store.isPresentToastMessage,
             text: "변경이 완료되었어요",
-            bottomPadding: 0
+            edge: .bottom,
+            padding: 75,
+            backgroundColor: Color(hex: 0x3F4247),
+            textColor: .white
         )
         .draggableBottomSheet(
             isShow: $store.isPresentNotificationPermissionBottomSheet,

--- a/NewsLetter/NewsLetter/Source/Data/Client/UserClient.swift
+++ b/NewsLetter/NewsLetter/Source/Data/Client/UserClient.swift
@@ -56,7 +56,7 @@ extension UserClient: DependencyKey {
             register: { _ in return 0 },
             update: { _, _ in return },
             fetchUser: { _ in
-                UserResponseDTO(id: 0, preferences: [.frontend], workingExperience: .student)
+                UserResponseDTO(id: 0, preferences: [.frontend], workingExperience: .student, isOnboarded: false, isCategoryChanged: false, categoryChangeCount: 0)
             }
         )
     }()

--- a/NewsLetter/NewsLetter/Source/Data/DTO/UserResponseDTO.swift
+++ b/NewsLetter/NewsLetter/Source/Data/DTO/UserResponseDTO.swift
@@ -8,5 +8,41 @@ import Foundation
 struct UserResponseDTO: Decodable {
     let id: Int
     let preferences: [Preference]
-    let workingExperience: WorkingExperience
+    /// 아직 경력을 선택하지 않은 유저는 서버가 null로 내려줍니다.
+    let workingExperience: WorkingExperience?
+    let isOnboarded: Bool
+    let isCategoryChanged: Bool
+    let categoryChangeCount: Int
+
+    init(
+        id: Int,
+        preferences: [Preference],
+        workingExperience: WorkingExperience?,
+        isOnboarded: Bool,
+        isCategoryChanged: Bool,
+        categoryChangeCount: Int
+    ) {
+        self.id = id
+        self.preferences = preferences
+        self.workingExperience = workingExperience
+        self.isOnboarded = isOnboarded
+        self.isCategoryChanged = isCategoryChanged
+        self.categoryChangeCount = categoryChangeCount
+    }
+
+    // 서버가 아직 내려주지 않거나 null일 수 있는 필드 때문에 디코딩 자체가 실패해 바텀시트가 조용히 안 뜨는 일이 없도록,
+    // 신규/선택 필드는 없거나 null이면 안전한 기본값으로 채웁니다.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(Int.self, forKey: .id)
+        preferences = try container.decode([Preference].self, forKey: .preferences)
+        workingExperience = try container.decodeIfPresent(WorkingExperience.self, forKey: .workingExperience)
+        isOnboarded = try container.decodeIfPresent(Bool.self, forKey: .isOnboarded) ?? false
+        isCategoryChanged = try container.decodeIfPresent(Bool.self, forKey: .isCategoryChanged) ?? true
+        categoryChangeCount = try container.decodeIfPresent(Int.self, forKey: .categoryChangeCount) ?? 0
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, preferences, workingExperience, isOnboarded, isCategoryChanged, categoryChangeCount
+    }
 }

--- a/NewsLetter/NewsLetter/Source/Data/UserActionHistory.swift
+++ b/NewsLetter/NewsLetter/Source/Data/UserActionHistory.swift
@@ -8,10 +8,6 @@
 import Foundation
 
 struct UserActionHistory {
-    /// 유저가 처음 앱을 실행했는지 여부
-    @UserDefaultWrapper(key: "isFirstAppLaunch", defaultValue: true)
-    static var isFirstAppLaunch: Bool
-    
     /// 유저가 첫 카드를 열고 닫았는지 여부
     @UserDefaultWrapper(key: "isFirstLook", defaultValue: false)
     static var isFirstLook: Bool
@@ -32,10 +28,6 @@ struct UserActionHistory {
     @UserDefaultWrapper(key: "isAlreadySetNotification", defaultValue: false)
     static var isAlreadySetNotification: Bool
     
-    /// 유저가 정보 등록을 거부한 날짜
-    @UserDefaultWrapper(key: "deniedDateWhenInputJobDetail", defaultValue: nil)
-    static var deniedDateWhenInputJobDetail: Date?
-    
     /// 유저가 알림 받기를 거부한 날짜
     @UserDefaultWrapper(key: "deniedDateWhenSetNotification", defaultValue: nil)
     static var deniedDateWhenSetNotification: Date?
@@ -51,4 +43,8 @@ struct UserActionHistory {
     /// 유저의 새로고침 사용 날짜
     @UserDefaultWrapper(key: "useRefreshDate", defaultValue: nil)
     static var useRefreshDate: Date?
+
+    /// 온보딩 둘째날 직군 변경 바텀시트 플로우가 종료되었는지 여부. true가 되면 서버에 온보딩 상태를 다시 확인하지 않습니다.
+    @UserDefaultWrapper(key: "isOnboardingFlowFinished", defaultValue: false)
+    static var isOnboardingFlowFinished: Bool
 }

--- a/NewsLetter/NewsLetter/Source/DesignSystem/Component/ConfirmAlertDialog.swift
+++ b/NewsLetter/NewsLetter/Source/DesignSystem/Component/ConfirmAlertDialog.swift
@@ -1,0 +1,124 @@
+//
+//  ConfirmAlertDialog.swift
+//  NewsLetter
+//
+
+import SwiftUI
+
+struct ConfirmAlertDialog: View {
+    /// `**강조 문구**` 형태로 감싼 구간만 세미볼드 + 진한 색으로 표시하고, 나머지는 Regular + 회색으로 표시합니다.
+    let message: String
+    let cancelTitle: String
+    let confirmTitle: String
+    let cancelHandler: () -> Void
+    let confirmHandler: () -> Void
+
+    private var styledMessage: Text {
+        message.components(separatedBy: "**")
+            .enumerated()
+            .reduce(Text("")) { result, element in
+                let (index, part) = element
+                let isEmphasized = index % 2 == 1
+                // 이 모달 안에서만 글자 단위로 줄바꿈이 가능하도록 글자 사이에 폭 없는 공백을 삽입합니다.
+                let charWrappablePart = part.map(String.init).joined(separator: "\u{200B}")
+                let segment = Text(charWrappablePart)
+                    .font(isEmphasized ? FontStyle.body16_semiBold.font : FontStyle.body16_regular.font)
+                    .foregroundColor(isEmphasized ? Color.semanticColor.text_strong : Color.semanticColor.text_secondary)
+                return result + segment
+            }
+    }
+
+    var body: some View {
+        VStack(spacing: 20) {
+            styledMessage
+                .multilineTextAlignment(.leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: 8) {
+                Button(action: cancelHandler) {
+                    Text(cancelTitle)
+                        .font(.body16_semiBold)
+                        .foregroundStyle(.semanticColor.text_secondary)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 52)
+                        .background(
+                            RoundedRectangle(cornerRadius: 14)
+                                .fill(.semanticColor.fill_primary)
+                        )
+                }
+
+                Button(action: confirmHandler) {
+                    Text(confirmTitle)
+                        .font(.body16_semiBold)
+                        .foregroundStyle(.semanticColor.text_strongInverse)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 52)
+                        .background(
+                            RoundedRectangle(cornerRadius: 14)
+                                .fill(.semanticColor.fill_primaryInversion)
+                        )
+                }
+            }
+        }
+        .padding(.top, 26)
+        .padding(.horizontal, 18)
+        .padding(.bottom, 16)
+        .frame(width: 315)
+        .background(
+            RoundedRectangle(cornerRadius: 24)
+                .fill(ColorPalette.white)
+        )
+    }
+}
+
+extension View {
+    func confirmAlertDialog(
+        isPresented: Binding<Bool>,
+        message: String,
+        cancelTitle: String = "취소",
+        confirmTitle: String = "확인",
+        cancelHandler: @escaping () -> Void = {},
+        confirmHandler: @escaping () -> Void
+    ) -> some View {
+        self.overlay {
+            if isPresented.wrappedValue {
+                ZStack {
+                    Color.black.opacity(0.4)
+                        .ignoresSafeArea()
+                        .onTapGesture {
+                            isPresented.wrappedValue = false
+                            cancelHandler()
+                        }
+
+                    ConfirmAlertDialog(
+                        message: message,
+                        cancelTitle: cancelTitle,
+                        confirmTitle: confirmTitle,
+                        cancelHandler: {
+                            isPresented.wrappedValue = false
+                            cancelHandler()
+                        },
+                        confirmHandler: {
+                            isPresented.wrappedValue = false
+                            confirmHandler()
+                        }
+                    )
+                }
+                .transition(.opacity)
+                .zIndex(Z.alertDialog)
+            }
+        }
+        .animation(.easeInOut, value: isPresented.wrappedValue)
+    }
+}
+
+#Preview {
+    ConfirmAlertDialog(
+        message: "관심 직군 변경은 **계정당 한 번만 가능**합니다. 변경 후에는 다른 직군으로 수정할 수 없습니다.",
+        cancelTitle: "취소",
+        confirmTitle: "변경하기",
+        cancelHandler: {},
+        confirmHandler: {}
+    )
+}

--- a/NewsLetter/NewsLetter/Source/DesignSystem/Constants.swift
+++ b/NewsLetter/NewsLetter/Source/DesignSystem/Constants.swift
@@ -14,6 +14,7 @@ enum Z {
     static let cardElevated: Double = 10
     static let carouselModal: Double = 20
     static let bottomSheet: Double = 50
+    static let alertDialog: Double = 60
 }
 
 typealias ColorSet = (main: Color, sub: Color)

--- a/NewsLetter/NewsLetter/Source/DesignSystem/View+.swift
+++ b/NewsLetter/NewsLetter/Source/DesignSystem/View+.swift
@@ -34,8 +34,8 @@ extension View {
         )
     }
     
-    func reportSuccessToast(isPresented: Binding<Bool>, topPadding: CGFloat) -> some View {
-        self.modifier(ReportSuccessToastMessage(isPresented: isPresented, topPadding: topPadding))
+    func reportSuccessToast(isPresented: Binding<Bool>, text: String = "제보가 완료되었어요", topPadding: CGFloat) -> some View {
+        self.modifier(ReportSuccessToastMessage(isPresented: isPresented, text: text, topPadding: topPadding))
     }
 
     func fontRangeLimited() -> some View {
@@ -99,6 +99,7 @@ struct ToastMessage: ViewModifier {
 
 struct ReportSuccessToastMessage: ViewModifier {
     @Binding var isPresented: Bool
+    let text: String
     let topPadding: CGFloat
 
     func body(content: Content) -> some View {
@@ -111,7 +112,7 @@ struct ReportSuccessToastMessage: ViewModifier {
                     .scaledToFit()
                     .frame(width: 24, height: 24)
 
-                Text("제보가 완료되었어요")
+                Text(text)
                     .font(.body15_regular)
                     .foregroundColor(.semanticColor.text_primary)
             }

--- a/NewsLetter/NewsLetter/Source/DesignSystem/View+.swift
+++ b/NewsLetter/NewsLetter/Source/DesignSystem/View+.swift
@@ -34,8 +34,24 @@ extension View {
         )
     }
     
-    func reportSuccessToast(isPresented: Binding<Bool>, text: String = "제보가 완료되었어요", topPadding: CGFloat) -> some View {
-        self.modifier(ReportSuccessToastMessage(isPresented: isPresented, text: text, topPadding: topPadding))
+    func reportSuccessToast(
+        isPresented: Binding<Bool>,
+        text: String = "제보가 완료되었어요",
+        edge: VerticalEdge = .top,
+        padding: CGFloat,
+        backgroundColor: Color = .white,
+        textColor: Color = .semanticColor.text_primary
+    ) -> some View {
+        self.modifier(
+            ReportSuccessToastMessage(
+                isPresented: isPresented,
+                text: text,
+                edge: edge,
+                padding: padding,
+                backgroundColor: backgroundColor,
+                textColor: textColor
+            )
+        )
     }
 
     func fontRangeLimited() -> some View {
@@ -100,10 +116,13 @@ struct ToastMessage: ViewModifier {
 struct ReportSuccessToastMessage: ViewModifier {
     @Binding var isPresented: Bool
     let text: String
-    let topPadding: CGFloat
+    let edge: VerticalEdge
+    let padding: CGFloat
+    let backgroundColor: Color
+    let textColor: Color
 
     func body(content: Content) -> some View {
-        ZStack(alignment: .top) {
+        ZStack(alignment: edge == .top ? .top : .bottom) {
             content
 
             HStack(spacing: 8) {
@@ -114,20 +133,20 @@ struct ReportSuccessToastMessage: ViewModifier {
 
                 Text(text)
                     .font(.body15_regular)
-                    .foregroundColor(.semanticColor.text_primary)
+                    .foregroundColor(textColor)
             }
             .padding(.leading, 12)
             .padding(.trailing, 16)
             .padding(.vertical, 12)
             .background(
                 Capsule()
-                    .fill(Color.white)
+                    .fill(backgroundColor)
                     .shadow(color: Color(red: 34/255, green: 62/255, blue: 119/255).opacity(0.12), radius: 8, x: 0, y: 0)
             )
             .opacity(isPresented ? 1 : 0)
-            .offset(y: isPresented ? 0 : -20)
+            .offset(y: isPresented ? 0 : (edge == .top ? -20 : 20))
             .animation(.bouncy, value: isPresented)
-            .padding(.top, topPadding)
+            .padding(edge == .top ? .top : .bottom, padding)
         }
         .onChange(of: isPresented) { _, newValue in
             if newValue == true {

--- a/NewsLetter/NewsLetter/Source/Utils/DateCalculator.swift
+++ b/NewsLetter/NewsLetter/Source/Utils/DateCalculator.swift
@@ -37,14 +37,6 @@ struct DateCalculator {
         return calculatePassDays(from: eventDate) >= 3
     }
     
-    static func isCanShowJobDetailBottomSheet() -> Bool {
-        guard let eventDate = UserActionHistory.deniedDateWhenInputJobDetail else {
-            return true
-        }
-
-        return calculatePassDays(from: eventDate) >= 7
-    }
-    
     static func calculatePassDays(from date: Date) -> Int {
         let today = Date()
         let calendar = Calendar.current


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
온보딩 둘째날 진입 시 직군 변경 바텀시트를 노출하고, 계정당 1회로 제한된 직군 변경 플로우를 추가합니다.


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
closes #131
- `GET /users/{userId}` 응답에 추가된 `isOnboarded`, `isCategoryChanged`, `categoryChangeCount` 필드를 반영하고, 서버가 필드를 내려주지 않거나 `workingExperience`가 `null`이어도 디코딩이 실패하지 않도록 `UserResponseDTO`를 보강했습니다.
- `RecommendReducer`: 둘째날(연속 방문일수 2 이상) 진입 시 `fetchOnboardingStatus`로 서버의 온보딩 상태를 먼저 확인하고, `isOnboarded == true`면 컨텐츠 조회보다 먼저 직군 변경 바텀시트를 노출하도록 순서를 강제했습니다. 바텀시트에서 선택/미선택을 확정한 뒤에만 컨텐츠를 조회합니다.
- 기존에 앱 최초 실행 시 바로 뜨던 직군 등록 바텀시트, 카드 3회 탭 유도 바텀시트는 새 온보딩 플로우로 대체되어 제거했습니다(관련 delegate action, `UserActionHistory` 플래그, `DateCalculator` 헬퍼 정리 포함).
- `ConfirmAlertDialog` 컴포넌트를 신규 추가해 "계정당 한 번만 가능" 확인 다이얼로그를 화면 전체 기준으로 노출합니다(기존 바텀시트는 자체 클리핑 영역 때문에 화면 전체에 다이얼로그를 띄울 수 없었습니다).
- `JobDetailBottomSheet`에 안내 문구, 확인 다이얼로그 연동(`requestChangeConfirmation`), `isCategoryChanged` 기반 버튼 활성화 로직을 추가했습니다. 최초 등록(기존 선택값 없음)에서는 다이얼로그 없이 바로 반영되고, 기존 정보를 수정할 때만 다이얼로그를 거칩니다.
- 설정 화면 "맞춤 설정" 진입 시 `UserInfo.userId`가 아직 없으면(로그인 완료 전 등) 로그인/등록을 먼저 시도하도록 보강했습니다. 기존엔 조용히 무시되어 바텀시트가 아예 뜨지 않는 문제가 있었습니다.
- 설정 화면에서 관심 직군이 실제로 바뀐 경우에만 `SettingReducer.Delegate.categoryUpdated`를 발행해 홈 추천 컨텐츠를 자동으로 새로고침합니다(경력만 바뀐 경우는 새로고침하지 않음).
- 직군 변경 완료 토스트를 탐색탭 제보 완료 토스트와 동일한 캡슐+체크마크 디자인으로 통일했습니다(위치는 하단, 색상은 다크 유지).

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
- `Source/DesignSystem/Component/ConfirmAlertDialog.swift` 신규 공용 컴포넌트가 추가됐습니다. 바텀시트/모달 위에 화면 전체 기준 확인 다이얼로그가 필요할 때 재사용 가능합니다.
- `RecommendReducer.Action`에 `resolveCardFetch`, `fetchOnboardingStatus`, `onboardingStatusResponse`, `onboardingJobDetailConfirmed`가 추가되고, 기존 `onAppear`의 카드 캐시 판단 로직이 `resolveCardFetch`로 분리됐습니다. `onAppear`를 참조하는 다른 코드가 있다면 흐름 변경 여부 확인이 필요합니다.
- `RecommendReducer.Delegate.presentJobDetailBottomSheet`, `HomeReducer.isPresentJobDetailBottomSheet` 등 3회 탭 유도 플로우 관련 코드를 제거했습니다. 혹시 이 플로우에 의존하는 다른 작업이 있다면 확인 부탁드립니다.
- `View+.swift`의 `reportSuccessToast`가 `text`/`edge`/`backgroundColor`/`textColor` 파라미터를 받도록 시그니처가 바뀌었습니다(기본값은 기존과 동일해 기존 호출부는 영향 없음).
- `UserResponseDTO.workingExperience`가 `WorkingExperience` → `WorkingExperience?`로 바뀌었습니다. 이 DTO를 사용하는 다른 코드가 있다면 옵셔널 처리 확인이 필요합니다.

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->
<!-- 참고한 디자인 시안, 피그마 링크 등이 있다면 직접 추가해주세요 -->


## 🔥 Test
<!-- Test -->
- [ ] 온보딩 첫째날에는 직군 변경 바텀시트가 뜨지 않고 정해진 컨텐츠만 노출되는지 확인
- [ ] 둘째날 진입 시 `isOnboarded == true`인 계정에서 컨텐츠 조회보다 먼저 바텀시트가 뜨는지 확인
- [ ] 바텀시트에서 직군/경력 선택 후 "맞춤 뉴스레터 보기" 확인 다이얼로그가 화면 전체 기준으로 뜨는지 확인
- [ ] 다이얼로그에서 "변경하기" 선택 시 직군 정보가 반영되고 컨텐츠가 새로고침되는지 확인
- [ ] 다이얼로그에서 "취소" 선택 시 바텀시트로 돌아오고 아무 것도 반영되지 않는지 확인
- [ ] 이미 직군을 변경한 계정(`isCategoryChanged == true`)은 "맞춤 뉴스레터 보기" 버튼이 비활성화되는지 확인
- [ ] 설정 > 맞춤 설정 진입 시(로그인 직후 포함) 바텀시트가 정상적으로 뜨는지 확인
- [ ] 설정에서 경력만 변경했을 때 홈 화면이 새로고침되지 않는지 확인
- [ ] 설정에서 관심 직군을 변경했을 때 홈 화면 추천 컨텐츠가 자동으로 새로고침되는지 확인
- [ ] 직군 변경 완료 토스트가 하단에 검정 배경 + 흰 텍스트 + 체크마크로 노출되는지 확인
- [ ] 카드 3회 탭 시 더 이상 직군 등록 바텀시트가 끼어들지 않고 카드 상세 모달만 뜨는지 확인